### PR TITLE
Fix formatting in Minecraft whitelist message for improved readability

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -96,7 +96,7 @@ modal.whitelist.step.twitch.error.not-connected=Du hast deinen Twitch-Account ni
 modal.whitelist.step.minecraft.label=Minecraft Name
 modal.whitelist.step.minecraft.invalid=Du musst einen gültigen Minecraft-Java Namen angeben.
 modal.whitelist.step.minecraft.already-whitelisted=Du bist bereits auf der Whitelist.
-modal.whitelist.step.minecraft.open=> Minecraft Name: `{0}`\n\n\
+modal.whitelist.step.minecraft.open=> Minecraft Name: ```{0}```\n\n\
 Vielen Dank für deine Whitelist Anfrage. \
 Du wirst nun auf die Whitelist hinzugefügt, sobald jemand aus dem Team Zeit findet.\
  Wir bitten um etwas Geduld.


### PR DESCRIPTION
This PR updates the message from the  bot, when a user creates a ticket for a whitelist.
The player minecraft name from the user is now send into a codeblock, which you can easily copy as a team member. 
This improves the whitelist tickets and the support https://i.imgur.com/HtygniD.png