### PR TITLE
Feat/ping role buttons

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.0.0-SNAPSHOT
+version=5.0.1-SNAPSHOT

--- a/src/main/kotlin/dev/slne/discord/discord/interaction/button/buttons/NotifSurvivalRoleButton.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/button/buttons/NotifSurvivalRoleButton.kt
@@ -1,0 +1,58 @@
+package dev.slne.discord.discord.interaction.button.buttons
+
+import dev.minn.jda.ktx.coroutines.await
+import dev.minn.jda.ktx.messages.Embed
+import dev.slne.discord.annotation.DiscordButton
+import dev.slne.discord.annotation.DiscordEmoji
+import dev.slne.discord.discord.interaction.button.DiscordButtonHandler
+import dev.slne.discord.message.EmbedColors
+import dev.slne.discord.message.translatable
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonInteraction
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle
+
+const val NotifySurvivalRoleTicketButtonId = "survival-notify-role"
+
+@DiscordButton(
+    NotifySurvivalRoleTicketButtonId,
+    "Survival-Server",
+    ButtonStyle.SUCCESS,
+    DiscordEmoji(unicode="🏕️")
+)
+class NotifySurvivalRoleButton() : DiscordButtonHandler {
+
+    override suspend fun ButtonInteractionEvent.onClick() {
+        val member = this.member ?: return
+        val guild = this.guild ?: return
+        val roleId = "1052595432913637469"
+        val role = guild.getRoleById(roleId) ?: return
+
+        if (member.roles.contains(role)) {
+            guild.removeRoleFromMember(member, role).await()
+
+            sendEmbed(true, interaction)
+            return
+        }
+        guild.addRoleToMember(member, role).await()
+        return
+    }
+
+    private suspend fun sendEmbed(state: Boolean, interaction: ButtonInteraction) {
+        val embed = Embed {
+            title = translatable("interaction.button.notify-survival.title")
+            description = if (state) {
+                translatable("interaction.button.notify-survival.description.added")
+            } else {
+                translatable("interaction.button.notify-survival.description.removed")
+            }
+            color = EmbedColors.NOTIFY_ROLE
+        }
+
+        interaction.deferReply(true)
+            .await()
+            .sendMessageEmbeds(embed)
+            .setEphemeral(true)
+            .await()
+    }
+
+}

--- a/src/main/kotlin/dev/slne/discord/discord/interaction/button/buttons/NotifyEventRoleButton.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/button/buttons/NotifyEventRoleButton.kt
@@ -1,0 +1,60 @@
+package dev.slne.discord.discord.interaction.button.buttons
+
+import dev.minn.jda.ktx.coroutines.await
+import dev.minn.jda.ktx.messages.Embed
+import dev.slne.discord.annotation.DiscordButton
+import dev.slne.discord.annotation.DiscordEmoji
+import dev.slne.discord.discord.interaction.button.DiscordButtonHandler
+import dev.slne.discord.message.EmbedColors
+import dev.slne.discord.message.translatable
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonInteraction
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle
+
+const val NotifyEventRoleTicketButtonId = "survival-notify-role"
+
+@DiscordButton(
+    NotifyEventRoleTicketButtonId,
+    "Event-Server",
+    ButtonStyle.SUCCESS,
+    DiscordEmoji(unicode="🎉")
+)
+
+
+class NotifyEventRoleButton() : DiscordButtonHandler {
+
+    override suspend fun ButtonInteractionEvent.onClick() {
+        val member = this.member ?: return
+        val guild = this.guild ?: return
+        val roleId = "1270779326140252182"
+        val role = guild.getRoleById(roleId) ?: return
+
+        if (member.roles.contains(role)) {
+            guild.removeRoleFromMember(member, role).await()
+
+            sendEmbed(true, interaction)
+            return
+        }
+        guild.addRoleToMember(member, role).await()
+        return
+    }
+
+    private suspend fun sendEmbed(state: Boolean, interaction: ButtonInteraction) {
+        val embed = Embed {
+            title = translatable("interaction.button.notify-event.title")
+            description = if (state) {
+                translatable("interaction.button.notify-event.description.added")
+            } else {
+                translatable("interaction.button.notify-event.description.removed")
+            }
+            color = EmbedColors.NOTIFY_ROLE
+        }
+
+        interaction.deferReply(true)
+            .await()
+            .sendMessageEmbeds(embed)
+            .setEphemeral(true)
+            .await()
+    }
+
+}

--- a/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/NotifyRoleButtonCommand.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/NotifyRoleButtonCommand.kt
@@ -17,7 +17,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.components.buttons.Button
 
-private const val ID = "ticket-buttons"
+private const val ID = "notify-buttons"
 
 @DiscordCommandMeta(
     name = ID,

--- a/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/NotifyRoleButtonCommand.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/NotifyRoleButtonCommand.kt
@@ -1,0 +1,55 @@
+package dev.slne.discord.discord.interaction.command.commands.misc
+
+import dev.minn.jda.ktx.coroutines.await
+import dev.minn.jda.ktx.interactions.components.row
+import dev.minn.jda.ktx.messages.MessageCreate
+import dev.slne.discord.annotation.DiscordCommandMeta
+import dev.slne.discord.annotation.toJdaButton
+import dev.slne.discord.discord.interaction.button.DiscordButtonProcessor
+import dev.slne.discord.discord.interaction.button.buttons.NotifyEventRoleTicketButtonId
+import dev.slne.discord.discord.interaction.button.buttons.NotifySurvivalRoleTicketButtonId
+import dev.slne.discord.discord.interaction.command.DiscordCommand
+import dev.slne.discord.guild.permission.CommandPermission
+import dev.slne.discord.message.EmbedColors
+import dev.slne.discord.message.translatable
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.components.buttons.Button
+
+private const val ID = "ticket-buttons"
+
+@DiscordCommandMeta(
+    name = ID,
+    description = "Print the ticket button to add a notify-role and embed.",
+    permission = CommandPermission.NOTIFY_BUTTONS
+)
+
+class NotifyRoleButtonCommand(private val buttonProcessor: DiscordButtonProcessor) : DiscordCommand() {
+    override suspend fun internalExecute(
+        interaction: SlashCommandInteractionEvent,
+        hook: InteractionHook
+    ) {
+        hook.deleteOriginal().await()
+
+        val channel = interaction.channel
+        val notifyRoleSurvival =
+            buttonProcessor[NotifySurvivalRoleTicketButtonId]?.first ?: error("Button not found")
+        val notifyRoleEvent =
+            buttonProcessor[NotifyEventRoleTicketButtonId]?.first ?: error("Button not found")
+
+        sendEmbed(notifyRoleSurvival.toJdaButton(), notifyRoleEvent.toJdaButton(), channel)
+    }
+
+    private suspend fun sendEmbed(button1: Button, button2 : Button, channel: MessageChannel) =
+        channel.sendMessage(MessageCreate {
+            embed {
+                title = translatable("interaction.button.notifybutton.title")
+                description =
+                    translatable("interaction.button.notifybutton.description")
+                color = EmbedColors.CREATE_TICKET
+            }
+
+            components += row(button1, button2)
+        }).await()
+}

--- a/src/main/kotlin/dev/slne/discord/guild/permission/CommandPermission.kt
+++ b/src/main/kotlin/dev/slne/discord/guild/permission/CommandPermission.kt
@@ -18,4 +18,5 @@ enum class CommandPermission(val permission: String) {
     FAQ("FAQ"),
     MISSING_INFORMATION("MISSING_INFORMATION"),
     REQUEST_ROLLBACK("REQUEST_ROLLBACK"),
+    NOTIFY_BUTTONS("NOTIFY_BUTTONS")
 }

--- a/src/main/kotlin/dev/slne/discord/message/EmbedColors.kt
+++ b/src/main/kotlin/dev/slne/discord/message/EmbedColors.kt
@@ -5,6 +5,7 @@ object EmbedColors {
     const val TICKET_REOPENED = 0x00ff00
     const val WL_QUERY = 0x000000
     const val SELECT_TICKET_TYPE = 0x1fbdd2
+    const val NOTIFY_ROLE = 0xe6c037
     const val CREATE_TICKET = 0xC5EF48
     const val ADD_TICKET_MEMBER = 0xC7D0D7
     const val ERROR_COLOR = 0xff0000

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -4,6 +4,17 @@ interaction.button.open-ticket.title=Ticket Typ auswählen
 interaction.button.open-ticket.description=Bitte wähle das passende Ticket aus, welches du öffnen möchtest.\n\
 \n\
 Informationen zu den unterschiedlichen Tickettypen findest du auf https://server.castcrafter.de/support
+## NotifyRoles
+interaction.button.notifybutton.title=Server-Benachrichtigung
+interaction.button.notifybutton.description=Du möchtest benachrichtigt werden, wenn es neue Updates und Ankündigungen gibt?\n\
+  Wähle aus, für welche Benachrichtigungen du informiert werden möchtest! ?\n\
+interaction.button.notify-survival.title=Survival-Server-Benachrichtigung
+interaction.button.notify-survival.title=Survival-Server-Benachrichtigung
+interaction.button.notify-survival.description.added=Die Benachrichtigungsrolle für den Survival-Server wurde dir hinzugefügt.
+interaction.button.notify-survival.description.removed=Die Benachrichtigungsrolle für den Survival-Server wurde dir entfernt.
+interaction.button.notify-event.title=Event-Server-Benachrichtigung
+interaction.button.notify-event.description.added=Die Benachrichtigungsrolle für den Event-Server wurde dir hinzugefügt.
+interaction.button.notify-event.description.removed=Die Benachrichtigungsrolle für den Event-Server wurde dir hinzugefügt.
 ### Commands
 # Request Rollback
 interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurückgesetzt werden sollen.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -96,7 +96,7 @@ modal.whitelist.step.twitch.error.not-connected=Du hast deinen Twitch-Account ni
 modal.whitelist.step.minecraft.label=Minecraft Name
 modal.whitelist.step.minecraft.invalid=Du musst einen gültigen Minecraft-Java Namen angeben.
 modal.whitelist.step.minecraft.already-whitelisted=Du bist bereits auf der Whitelist.
-modal.whitelist.step.minecraft.open=> Minecraft Name: `{0}`\n\n\
+modal.whitelist.step.minecraft.open=> Minecraft Name: ```{0}```\n\n\
 Vielen Dank für deine Whitelist Anfrage. \
 Du wirst nun auf die Whitelist hinzugefügt, sobald jemand aus dem Team Zeit findet.\
  Wir bitten um etwas Geduld.


### PR DESCRIPTION
cleanup, ping roles for event and survival should now be available from arty via Buttons which are below a embed. 
You can send the Embed via command `/notify-buttons`.
