### PR TITLE
feat: Add maintenance FAQ question and answer for user clarity

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CommitMessageInspectionProfile">
-    <profile version="1.0">
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    </profile>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.0.2-SNAPSHOT
+version=5.0.3-SNAPSHOT

--- a/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/FAQCommand.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/FAQCommand.kt
@@ -68,6 +68,11 @@ class FAQCommand : DiscordCommand() {
             "read-the-docs",
             translatable("command.faq.questions.read-the-docs"),
             translatable("command.faq.questions.read-the-docs.answer")
+        ),
+        Question(
+            "maintenance",
+            translatable("command.faq.questions.maintenance"),
+            translatable("command.faq.questions.maintenance.answer")
         )
     ).associateBy { it.identifier }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,68 +1,68 @@
 ### Interactions
 ## Show Admin Panel
 interaction.context.menu.admin-panel.button=Open Admin Panel
-interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für den Benutzer {0} zu öffnen.
-interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-Einträge für diesen Benutzer gefunden. Daher können wir den Link zum Admin-Panel nicht öffnen.
+interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r den Benutzer {0} zu Ã¶ffnen.
+interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-EintrÃ¤ge fÃ¼r diesen Benutzer gefunden. Daher kÃ¶nnen wir den Link zum Admin-Panel nicht Ã¶ffnen.
 interaction.context.menu.admin-panel.no-private-message-allowed=Du hast private Nachrichten deaktiviert oder der Bot darf dir keine Nachrichten senden.
 interaction.context.menu.ticket-admin-panel.not-a-thread=Dieser Befehl kann nur in einem Thread-Kanal verwendet werden.
 interaction.context.menu.ticket-admin-panel.not-a-ticket=Dieser Befehl kann nur in einem Ticket-Thread verwendet werden.
-interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für das Ticket {0} zu öffnen.
+interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r das Ticket {0} zu Ã¶ffnen.
 ## Open Ticket
-interaction.button.open-ticket.title=Ticket Typ auswählen
-interaction.button.open-ticket.description=Bitte wähle das passende Ticket aus, welches du öffnen möchtest.\n\
+interaction.button.open-ticket.title=Ticket Typ auswÃ¤hlen
+interaction.button.open-ticket.description=Bitte wÃ¤hle das passende Ticket aus, welches du Ã¶ffnen mÃ¶chtest.\n\
 \n\
 Informationen zu den unterschiedlichen Tickettypen findest du auf https://server.castcrafter.de/support
 ### Commands
 # Request Rollback
-interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurückgesetzt werden sollen.
-interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurückgesetzt werden sollen.
+interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurÃ¼ckgesetzt werden sollen.
+interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurÃ¼ckgesetzt werden sollen.
 interaction.command.rollback.sub.full.description=Markiert den Rollback als einen kompletten Rollback.
-interaction.command.rollback.sub.full.arg.reason=Der Grund für den kompletten Rollback.
+interaction.command.rollback.sub.full.arg.reason=Der Grund fÃ¼r den kompletten Rollback.
 interaction.command.rollback.sub.timed.description=Markiert den Rollback als einen zeitlich begrenzten Rollback.
-interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurückgesetzt werden soll.
+interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurÃ¼ckgesetzt werden soll.
 ## Tickets
 ticket.open.success=Dein "{0}"-Ticket wurde erfolgreich erstellt!
 # Ticket Button
 interaction.command.ticket.ticket-button.title=Ticket erstellen
-interaction.command.ticket.ticket-button.description=Du möchtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag für den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
+interaction.command.ticket.ticket-button.description=Du mÃ¶chtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag fÃ¼r den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
 \n\
 Bitte mache dich **vorher** mit unterschiedlichen Tickettypen vertraut!\n\
-Die Übersicht findest du hier: https://server.castcrafter.de/support\n\
+Die Ãœbersicht findest du hier: https://server.castcrafter.de/support\n\
 \n\
-Allgemeine Fragen sollten in den dafür vorgesehenen öffentlichen Kanälen gestellt werden.\n\
+Allgemeine Fragen sollten in den dafÃ¼r vorgesehenen Ã¶ffentlichen KanÃ¤len gestellt werden.\n\
 \n\
-Wir bemühen uns die Tickets schnellstmöglich zu bearbeiten.\
-  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets länger dauern kann.
+Wir bemÃ¼hen uns die Tickets schnellstmÃ¶glich zu bearbeiten.\
+  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets lÃ¤nger dauern kann.
 # Ticket Close
-interaction.command.ticket.close.arg.reason=Der Grund für das Schließen des Tickets
-interaction.command.ticket.close.closing=Schließe Ticket...
+interaction.command.ticket.close.arg.reason=Der Grund fÃ¼r das SchlieÃŸen des Tickets
+interaction.command.ticket.close.closing=SchlieÃŸe Ticket...
 # Ticket Dependencies not met
-interaction.command.ticket.dependencies-not-met.close-reason=Du erfüllst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket eröffnest.
+interaction.command.ticket.dependencies-not-met.close-reason=Du erfÃ¼llst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket erÃ¶ffnest.
 # Ticket member add
-interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefügt werden soll
-interaction.command.ticket.member.add.adding=Hinzufügen...
-interaction.command.ticket.member.add.checking-bot=Überprüfe, ob der Bot hinzugefügt werden soll...
-interaction.command.ticket.member.add.checking-already-in-ticket=Überprüfe, ob der Nutzer bereits im Ticket ist...
-interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefügt.
+interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefÃ¼gt werden soll
+interaction.command.ticket.member.add.adding=HinzufÃ¼gen...
+interaction.command.ticket.member.add.checking-bot=ÃœberprÃ¼fe, ob der Bot hinzugefÃ¼gt werden soll...
+interaction.command.ticket.member.add.checking-already-in-ticket=ÃœberprÃ¼fe, ob der Nutzer bereits im Ticket ist...
+interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefÃ¼gt.
 interaction.command.ticket.member.embed.title=Willkommen im Ticket!
-interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefügt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
-interaction.command.ticket.member.embed.footer=Hinzugefügt von {0}
+interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefÃ¼gt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
+interaction.command.ticket.member.embed.footer=HinzugefÃ¼gt von {0}
 # Ticket member remove
 interaction.command.ticket.member.remove.arg.member=Der Benutzer, der entfernt werden soll
 interaction.command.ticket.member.remove.removing=Entferne...
 interaction.command.ticket.member.remove.removed=Der Nutzer wurde erfolgreich entfernt.
-interaction.command.ticket.member.remove.checking-bot=Überprüfe, ob der Bot entfernt werden soll...
-interaction.command.ticket.member.remove.checking-in-ticket=Überprüfe, ob der Nutzer im Ticket ist...
+interaction.command.ticket.member.remove.checking-bot=ÃœberprÃ¼fe, ob der Bot entfernt werden soll...
+interaction.command.ticket.member.remove.checking-in-ticket=ÃœberprÃ¼fe, ob der Nutzer im Ticket ist...
 interaction.command.ticket.member.remove.announcement={0} wurde von {1} aus dem Ticket entfernt.
 interaction.command.ticket.member.remove.error=Der Nutzer konnte nicht entfernt werden.
 # Whitelist
-interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefügt werden soll.
+interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefÃ¼gt werden soll.
 interaction.command.ticket.whitelist.arg.minecraft-name=Der Minecraft-Name des Spielers
 interaction.command.ticket.whitelist.arg.twitch-name=Der Twitch-Name des Spielers
 interaction.command.ticket.whitelist.uuid-fetching=UUID wird abgerufen...
-interaction.command.ticket.whitelist.checking=Überprüfe auf vorhandene Whitelists...
-interaction.command.ticket.whitelist.adding=Füge zur Whitelist hinzu...
-interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefügt...
+interaction.command.ticket.whitelist.checking=ÃœberprÃ¼fe auf vorhandene Whitelists...
+interaction.command.ticket.whitelist.adding=FÃ¼ge zur Whitelist hinzu...
+interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefÃ¼gt...
 interaction.command.ticket.whitelist.already-whitelisted=Der Spieler befindet sich bereits auf der Whitelist.
 interaction.command.ticket.whitelist.added={0} befindet sich nun auf der Whitelist.
 interaction.command.ticket.wlquery.querying=Frage Whitelist Informationen ab...
@@ -85,10 +85,10 @@ interaction.command.ticket.whitelist.role.remove.failed={0} Benutzer konnten nic
 # Missing information
 interaction.command.ticket.missing-information.arg.user=Der Benutzer, der die Nachricht erhalten soll.
 interaction.command.ticket.missing-information.message.title=Fehlende Informationen
-interaction.command.ticket.missing-information.message.content=Vielen Dank für deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu können.\n\
+interaction.command.ticket.missing-information.message.content=Vielen Dank fÃ¼r deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu kÃ¶nnen.\n\
   Bitte stelle sicher, dass du die folgenden Punkte bereitstellst:\n\n\
   - **Genaue Koordinaten**, z. B. `110 64 60` (Standort eines Containers)\n\
-  - **Dimension**, z. B. *Nether*\n\
+  - **Dimension**, z.Â B. *Nether*\n\
   - **Beschreibung** des Problems\n\
   - **Server**, auf dem der Fehler aufgetreten ist
 # Whitelist
@@ -97,46 +97,46 @@ modal.whitelist.step.twitch.question.yes=Ja, ich habe meinen Twitch-Account verb
 modal.whitelist.step.twitch.question.no=Nein, ich habe meinen Twitch-Account nicht verbunden oder folge CastCrafter nicht auf Twitch.
 modal.whitelist.step.twitch.error.not-connected=Du hast deinen Twitch-Account nicht mit Discord verbunden.
 modal.whitelist.step.minecraft.label=Minecraft Name
-modal.whitelist.step.minecraft.invalid=Du musst einen gültigen Minecraft-Java Namen angeben.
+modal.whitelist.step.minecraft.invalid=Du musst einen gÃ¼ltigen Minecraft-Java Namen angeben.
 modal.whitelist.step.minecraft.already-whitelisted=Du bist bereits auf der Whitelist.
 modal.whitelist.step.minecraft.open=> Minecraft Name: ```{0}```\n\n\
-Vielen Dank für deine Whitelist Anfrage. \
-Du wirst nun auf die Whitelist hinzugefügt, sobald jemand aus dem Team Zeit findet. \
+Vielen Dank fÃ¼r deine Whitelist Anfrage. \
+Du wirst nun auf die Whitelist hinzugefÃ¼gt, sobald jemand aus dem Team Zeit findet. \
 Wir bitten um etwas Geduld.
 modal.whitelist.title=Whitelist Ticket
-modal.whitelist.description=Whitelist Anfrage für den Survival Server
+modal.whitelist.description=Whitelist Anfrage fÃ¼r den Survival Server
 # Report
 modal.report.step.selection.griefing.title=Auf welchem Server wurdest du gegrieft?
 modal.report.step.selection.griefing.survival1.label=Survival 01
 modal.report.step.selection.griefing.survival2.label=Survival 02
-modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wähle diese Option!
+modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wÃ¤hle diese Option!
 modal.report.step.selection.griefing.event.label=Event
-modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wähle diese Option!
+modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wÃ¤hle diese Option!
 modal.report.step.griefing.input.world.label=Welt
 modal.report.step.griefing.input.world.placeholder=overworld
 modal.report.step.griefing.input.xyz.label=X Y Z
 modal.report.step.griefing.input.xyz.placeholder=123 64 321
 modal.report.step.griefing.input.what-griefed.label=Was wurde gegrieft?
-modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschädigten Strukturen oder gestohlenen Gegenstände.
-modal.report.step.griefing.input.additional-info.label=Zusätzliche Informationen
-modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen möchtest?
+modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschÃ¤digten Strukturen oder gestohlenen GegenstÃ¤nde.
+modal.report.step.griefing.input.additional-info.label=ZusÃ¤tzliche Informationen
+modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen mÃ¶chtest?
 modal.report.step.griefing.messages.server=> Server: `{0}`
 modal.report.step.griefing.messages.location=> Location: `{0}` - `{1}`
 modal.report.step.player.input.reporting-player.label=Dein Spielname
 modal.report.step.player.input.reason.label=Grund
 modal.report.step.player.input.reason.placeholder=Was hat der Spielende getan?
 modal.report.step.player.messages.reporting-player=> Meldender Spielende: `{0}`
-modal.report.step.type.selection.title=Möchtest du Griefing oder einen Spieler Melden?
+modal.report.step.type.selection.title=MÃ¶chtest du Griefing oder einen Spieler Melden?
 modal.report.step.type.selection.griefing.label=Griefing
-modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wähle diese Option!
+modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wÃ¤hle diese Option!
 modal.report.step.type.selection.player.label=Spieler
-modal.report.step.type.selection.player.description=Du möchtest einen Spieler melden? Dann wähle diese Option!
+modal.report.step.type.selection.player.description=Du mÃ¶chtest einen Spieler melden? Dann wÃ¤hle diese Option!
 modal.report.step.type.input.griefing.own-name=Dein Spielername
 modal.report.step.type.input.report.reported-player=Zu meldender Spielername
 modal.report.step.type.messages.player-name=> Spielername: `{0}`
 modal.report.title=Report
-modal.report.description=Melde Griefing, Cheating oder andere Regelverstöße.
-modal.report.message=Danke für deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir den Vorfall untersuchen.
+modal.report.description=Melde Griefing, Cheating oder andere RegelverstÃ¶ÃŸe.
+modal.report.message=Danke fÃ¼r deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir den Vorfall untersuchen.
 # Unban
 modal.unban.step.type.selection.title=Wurdest du wegen `Unerlaubte Clientmodifikationen` gebannt?
 modal.unban.step.type.selection.yes.label=Ja
@@ -148,25 +148,25 @@ modal.unban.step.punishment-id.input.placeholder=Deine Punishment ID
 modal.unban.step.punishment-id.messages.punishment-id=> Punishment ID: ``{0}``
 modal.unban.step.punishment-id.error.invalid=Es konnte kein Ausschluss mit der eingegebenen ID gefunden werden!
 modal.unban.step.appeal.input.appeal.label=Dein Entbannungsantrag
-modal.unban.step.appeal.input.appeal.placeholder=Erkläre, warum du entbannt werden möchtest und was du aus deinem Verhalten gelernt hast.
+modal.unban.step.appeal.input.appeal.placeholder=ErklÃ¤re, warum du entbannt werden mÃ¶chtest und was du aus deinem Verhalten gelernt hast.
 modal.unban.step.appeal.messages.appeal.title=# Entbannungsantrag
 modal.unban.step.appeal.messages.appeal=> {0}
 modal.unban.step.modlist.input.label=Modifikationsliste
 modal.unban.step.modlist.input.placeholder=Bitte gebe hier AUSNAHMSLOS ALLE Modifikationen an, die du benutzt hast! (Screenshot / Liste)
 modal.unban.step.modlist.messages.open=> Modifikationsliste: [{0}]
 modal.unban.title=Entbannungsantrag
-modal.unban.description=Entbannungsanträge für den Community Server
-modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von Entbannungsanträgen während laufender Events **bis zu 24 Stunden** dauern kann!
+modal.unban.description=EntbannungsantrÃ¤ge fÃ¼r den Community Server
+modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von EntbannungsantrÃ¤gen wÃ¤hrend laufender Events **bis zu 24 Stunden** dauern kann!
 # Bug Report
 modal.bug-report.title=Bug Report
 modal.bug-report.description=Fehler gefunden? Melde ihn hier.
-modal.bug-report.message=Danke für deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kümmern.\
-  \ Bitte hab etwas Geduld, während wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
-  \ die den Fehler zeigen, füge diese bitte hinzu.
+modal.bug-report.message=Danke fÃ¼r deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern.\
+  \ Bitte hab etwas Geduld, wÃ¤hrend wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
+  \ die den Fehler zeigen, fÃ¼ge diese bitte hinzu.
 modal.bug-report.step.minecraft.label=Minecraft Name
 modal.bug-report.step.minecraft.messages.minecraft-name=> Minecraft Name: `{0}`
-modal.bug-report.step.report.label=Welchen Bug möchtest du melden?
-modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie möglich.
+modal.bug-report.step.report.label=Welchen Bug mÃ¶chtest du melden?
+modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie mÃ¶glich.
 modal.bug-report.step.report.message.title=# Bug Report
 # Minecraft Support
 modal.minecraft-support.minecraft-name.label=Minecraft Name
@@ -174,115 +174,116 @@ modal.minecraft-support.minecraft-name.placeholder=Dein Minecraft Name
 modal.minecraft-support.minecraft-name.message=> Minecraft Name: `{0}`
 # Common support
 modal.support.step.input.label=Dein Anliegen
-modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie möglich.
+modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie mÃ¶glich.
 modal.support.step.input.message=# Anliegen
 # Survival support
 modal.support.survival.titel=Survival Support
-modal.support.survival.description=Anliegen bezüglich des Survival Servers
-modal.support.survival.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
+modal.support.survival.description=Anliegen bezÃ¼glich des Survival Servers
+modal.support.survival.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
 # Event support
 modal.support.event.titel=Event Support
-modal.support.event.description=Anliegen bezüglich des Event Servers
-modal.support.event.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
+modal.support.event.description=Anliegen bezÃ¼glich des Event Servers
+modal.support.event.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
 # Discord support
 modal.support.discord.titel=Discord Support
-modal.support.discord.description=Anliegen bezüglich des Discord Servers
-modal.support.discord.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
+modal.support.discord.description=Anliegen bezÃ¼glich des Discord Servers
+modal.support.discord.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
 ### Errors
 error.generic=Ein Fehler ist aufgetreten.
 error.no-guild=Du musst dich auf einem Server befinden!
 error.server-not-registered=Dieser Server ist nicht registriert!
-error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszuführen!
-error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszuführen.
+error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszufÃ¼hren!
+error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszufÃ¼hren.
 error.command.arg.missing.user=Du musst einen Benutzer angeben.
 error.command.arg.missing.role=Du musst eine Rolle angeben.
 error.command.arg.missing.number=Du musst eine Zahl angeben.
 error.command.arg.missing.boolean=Du musst einen Wahrheitswert angeben.
 error.command.arg.missing.string=Du musst einen Text angeben.
 error.command.arg.missing.attachment=Du musst eine Anlage angeben.
-error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszuführen!
-error.ticket.close=Es ist ein Fehler beim Schließen des Tickets aufgetreten.
+error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszufÃ¼hren!
+error.ticket.close=Es ist ein Fehler beim SchlieÃŸen des Tickets aufgetreten.
 error.ticket.close.not-found=Das Ticket konnte nicht gefunden werden.
 error.ticket.close.not-closable=Der Ticket-Channel kann nicht geschlossen werden.
 error.ticket.close.already-closing=Das Ticket wird bereits geschlossen.
 error.ticket.close.already-closed=Das Ticket ist bereits geschlossen.
-error.ticket.bot.add=Du kannst den Bot nicht hinzufügen.
+error.ticket.bot.add=Du kannst den Bot nicht hinzufÃ¼gen.
 error.ticket.bot.remove=Du kannst den Bot nicht entfernen.
 error.ticket.member.already-in-ticket=Dieser Nutzer ist bereits in diesem Ticket.
 error.ticket.member.not-in-ticket=Dieser Nutzer ist nicht in diesem Ticket.
-error.ticket.add.member=Der Nutzer konnte nicht hinzugefügt werden.
+error.ticket.add.member=Der Nutzer konnte nicht hinzugefÃ¼gt werden.
 error.ticket.remove.member=Der Nutzer konnte nicht entfernt werden.
 error.minecraft.not-found=Der Spieler konnte nicht gefunden werden.
 error.ticket.whitelist=Es ist ein Fehler aufgetreten. Die Whitelist konnte nicht erstellt werden.
 error.ticket.wlquery.no-user=Es wurde kein Benutzer angegeben.
-error.whitelist.query.no-results=Es wurden keine Whitelist Einträge für `{0}` gefunden.
+error.whitelist.query.no-results=Es wurden keine Whitelist EintrÃ¤ge fÃ¼r `{0}` gefunden.
 error.whitelist.role-not-registered=Die Whitelist Rolle ist nicht registriert.
 error.whitelist.change.not-whitelisted=Der Spieler ist nicht auf der Whitelist.
-error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geöffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
-error.ticket.permission.open=Du hast nicht die benötigten Berechtigungen, um ein Ticket zu erstellen!
+error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geÃ¶ffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
+error.ticket.permission.open=Du hast nicht die benÃ¶tigten Berechtigungen, um ein Ticket zu erstellen!
 error.ticket.whitelist.not-whitelisted=Du musst auf der Whitelist sein, um dieses Ticket zu erstellen.
 error.ticket.whitelist.already-whitelisted=Du bist bereits auf der Whitelist und kannst dieses Ticket nicht erstellen.
-error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknüpfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
-error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht öffentlich. Bitte stelle sicher, dass dein Profil öffentlich ist, damit wir deine Verknüpfung überprüfen können.
+error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknÃ¼pfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
+error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht Ã¶ffentlich. Bitte stelle sicher, dass dein Profil Ã¶ffentlich ist, damit wir deine VerknÃ¼pfung Ã¼berprÃ¼fen kÃ¶nnen.
 ## Misc
-# Don´t ask to ask
+# DonÂ´t ask to ask
 command.dontasktoask.message.title=Frag einfach direkt.
 command.dontasktoask.message.content=Wenn du eine Frage hast, stell sie einfach. Suche nicht nach \
   bestimmten Personen oder Experten. Frage nicht, ob du eine Frage stellen darfst oder ob jemand \
-  wach oder verfügbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
+  wach oder verfÃ¼gbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
 # How to join
 command.howtojoin.arg.user.description=Der Benutzer, der die Anleitung erhalten soll.
 command.howtojoin.message.title=Wie kannst du den CastCrafter-Server betreten?
-command.howtojoin.message.content=Möchtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
+command.howtojoin.message.content=MÃ¶chtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
   - Schau dir unsere Anleitung hier an: [Anleitung zum Beitreten](https://server.castcrafter.de/how-to-join)\n\
-  - Du brauchst keine Whitelist für den Event-Server.\n\
-  - Für den Survival-Server brauchst du eine Whitelist.\n\n\
+  - Du brauchst keine Whitelist fÃ¼r den Event-Server.\n\
+  - FÃ¼r den Survival-Server brauchst du eine Whitelist.\n\n\
    -# Wir freuen uns, dich bald auf dem Server zu sehen!
 # FAQ
 command.faq.arg.question=Die Frage, die beantwortet werden soll.
 command.faq.arg.user=Der Benutzer, der die Antwort erhalten soll.
-command.faq.questions.connect-twitch-with-discord=Wie verknüpfe ich meinen Twitch Account mit Discord?
-command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknüpfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
+command.faq.questions.connect-twitch-with-discord=Wie verknÃ¼pfe ich meinen Twitch Account mit Discord?
+command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknÃ¼pfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
 command.faq.questions.banned=Ich wurde gebannt. Was kann ich tun?
 command.faq.questions.banned.answer=Wenn du denkst, dir ist mit einem Ausschluss vom Server unrecht getan, erstelle einen [Entbannungsantrag](https://server.castcrafter.de/support#unban-ticket)!
-command.faq.questions.event=Wann findet das nächste Event statt?
-command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekündigt.
+command.faq.questions.event=Wann findet das nÃ¤chste Event statt?
+command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekÃ¼ndigt.
 command.faq.questions.open-ticket=Wie erstelle ich ein Ticket?
 command.faq.questions.open-ticket.answer=Eine Anleitung, wie du ein Ticket erstellen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/support.html)
 command.faq.questions.rulebook=Regelwerk
 command.faq.questions.rulebook.answer=Alle Regeln, die auf dem Server gelten, findest du hier: \
   [Regelwerk](https://server.castcrafter.de/rules)\n\n\
-  Bitte lies die Regeln sorgfältig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
-  -# Bei Events **können** die Regeln abweichen. \
-  Diese Änderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
+  Bitte lies die Regeln sorgfÃ¤ltig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
+  -# Bei Events **kÃ¶nnen** die Regeln abweichen. \
+  Diese Ã„nderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
 command.faq.questions.server-modpack=Offizielles Server Modpack
 command.faq.questions.server-modpack.answer=Um das Spielerlebnis auf dem Server zu optimieren \
-  gibt es ein offizielles Modpack, welches ausschließlich getestete Modifikationen enthält. \
+  gibt es ein offizielles Modpack, welches ausschlieÃŸlich getestete Modifikationen enthÃ¤lt. \
   Alle enthaltenen Mods sind erlaubt und mit dem Server kompatibel.\n\
-  **Das Modpack könnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
-  -# **Änderungen am Modpack oder das Hinzufügen zusätzlicher Mods können zu Inkompatibilitäten und \
-  unter Umständen zu einem Ausschluss des Servers führen. \
-  Wir übernehmen keine Verantwortung für modifizierte Versionen des Modpacks.**
+  **Das Modpack kÃ¶nnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
+  -# **Ã„nderungen am Modpack oder das HinzufÃ¼gen zusÃ¤tzlicher Mods kÃ¶nnen zu InkompatibilitÃ¤ten und \
+  unter UmstÃ¤nden zu einem Ausschluss des Servers fÃ¼hren. \
+  Wir Ã¼bernehmen keine Verantwortung fÃ¼r modifizierte Versionen des Modpacks.**
 command.faq.questions.problem-ressourcepack=Probleme mit dem Ressourcenpaket
-command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket läd nicht richtig oder du \
-  erhältst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
+command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket lÃ¤d nicht richtig oder du \
+  erhÃ¤ltst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
   Hier findest du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#resourcepack-issues)
 command.faq.questions.problem-connection=Verbindungsprobleme / Netzwerk Lags
 command.faq.questions.problem-connection.answer=Du kannst dich nicht mit dem Server verbinden, \
-  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmäßig starke Lags?\n\
+  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmÃ¤ÃŸig starke Lags?\n\
   Hier findet du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#connection-issues)
 command.faq.questions.read-the-docs=Dokumentation
-command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausführlichen \
+command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausfÃ¼hrlichen \
   Dokumentation beantwortet: [Dokumentation](https://server.castcrafter.de/community-server-landing-page)\n\n\
-  Für detaillierte Anleitungen, Tipps und häufig gestellte Fragen besuche den obigen Link.
+  FÃ¼r detaillierte Anleitungen, Tipps und hÃ¤ufig gestellte Fragen besuche den obigen Link.
 command.faq.questions.maintenance=Wartungsarbeiten
 command.faq.questions.maintenance.answer=Aktuell finden Wartungsarbeiten statt. \
-  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal.
+  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal und \
+  in der [Dokumentation](https://server.castcrafter.de/current-server-issues.html#server-lockdown).
 ### Menus
 ## Tickets menu
-menu.ticket.select.placeholder=Ticket auswählen
+menu.ticket.select.placeholder=Ticket auswÃ¤hlen
 ### Other
 # Whitelist
 whitelist.query.embed.title=Whitelist Query
@@ -291,12 +292,12 @@ whitelist.query.embed.description=Whitelist Informationen
 whitelist.query.embed.field.minecraft-name=Minecraft Name
 whitelist.query.embed.field.twitch-name=Twitch Link
 whitelist.query.embed.field.discord-user=Discord User
-whitelist.query.embed.field.added-by=Hinzugefügt von
+whitelist.query.embed.field.added-by=HinzugefÃ¼gt von
 whitelist.query.embed.field.uuid=UUID
 whitelist.query.embed.field.blocked=Blockiert
-whitelist.query.start=WlQuery für: `{0}`
+whitelist.query.start=WlQuery fÃ¼r: `{0}`
 # Tickets
-ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von Inaktivität automatisch geschlossen.
+ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von InaktivitÃ¤t automatisch geschlossen.
 # Common
 common.yes=Ja
 common.no=Nein

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -279,7 +279,7 @@ command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in un
   Für detaillierte Anleitungen, Tipps und häufig gestellte Fragen besuche den obigen Link.
 command.faq.questions.maintenance=Wartungsarbeiten
 command.faq.questions.maintenance.answer=Aktuell finden Wartungsarbeiten statt. \
-  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal und \
+  Bitte habe ein wenig Geduld. Weitere Informationen findest du unter https://discord.com/channels/133198459531558912/980810495877607524 und \
   in der [Dokumentation](https://server.castcrafter.de/current-server-issues.html#server-lockdown)
 ### Menus
 ## Tickets menu

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -279,7 +279,8 @@ command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in un
   Für detaillierte Anleitungen, Tipps und häufig gestellte Fragen besuche den obigen Link.
 command.faq.questions.maintenance=Wartungsarbeiten
 command.faq.questions.maintenance.answer=Aktuell finden Wartungsarbeiten statt. \
-  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal.
+  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal und \
+  in der [Dokumentation](https://server.castcrafter.de/current-server-issues.html#server-lockdown)
 ### Menus
 ## Tickets menu
 menu.ticket.select.placeholder=Ticket auswählen

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -277,6 +277,9 @@ command.faq.questions.read-the-docs=Dokumentation
 command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausführlichen \
   Dokumentation beantwortet: [Dokumentation](https://server.castcrafter.de/community-server-landing-page)\n\n\
   Für detaillierte Anleitungen, Tipps und häufig gestellte Fragen besuche den obigen Link.
+command.faq.questions.maintenance=Wartungsarbeiten
+command.faq.questions.maintenance.answer=Aktuell finden Wartungsarbeiten statt. \
+  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal.
 ### Menus
 ## Tickets menu
 menu.ticket.select.placeholder=Ticket auswählen

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,68 +1,68 @@
 ### Interactions
 ## Show Admin Panel
 interaction.context.menu.admin-panel.button=Open Admin Panel
-interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r den Benutzer {0} zu Ã¶ffnen.
-interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-EintrÃ¤ge fÃ¼r diesen Benutzer gefunden. Daher kÃ¶nnen wir den Link zum Admin-Panel nicht Ã¶ffnen.
+interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für den Benutzer {0} zu öffnen.
+interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-Einträge für diesen Benutzer gefunden. Daher können wir den Link zum Admin-Panel nicht öffnen.
 interaction.context.menu.admin-panel.no-private-message-allowed=Du hast private Nachrichten deaktiviert oder der Bot darf dir keine Nachrichten senden.
 interaction.context.menu.ticket-admin-panel.not-a-thread=Dieser Befehl kann nur in einem Thread-Kanal verwendet werden.
 interaction.context.menu.ticket-admin-panel.not-a-ticket=Dieser Befehl kann nur in einem Ticket-Thread verwendet werden.
-interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r das Ticket {0} zu Ã¶ffnen.
+interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für das Ticket {0} zu öffnen.
 ## Open Ticket
-interaction.button.open-ticket.title=Ticket Typ auswÃ¤hlen
-interaction.button.open-ticket.description=Bitte wÃ¤hle das passende Ticket aus, welches du Ã¶ffnen mÃ¶chtest.\n\
+interaction.button.open-ticket.title=Ticket Typ auswählen
+interaction.button.open-ticket.description=Bitte wähle das passende Ticket aus, welches du öffnen möchtest.\n\
 \n\
 Informationen zu den unterschiedlichen Tickettypen findest du auf https://server.castcrafter.de/support
 ### Commands
 # Request Rollback
-interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurÃ¼ckgesetzt werden sollen.
-interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurÃ¼ckgesetzt werden sollen.
+interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurückgesetzt werden sollen.
+interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurückgesetzt werden sollen.
 interaction.command.rollback.sub.full.description=Markiert den Rollback als einen kompletten Rollback.
-interaction.command.rollback.sub.full.arg.reason=Der Grund fÃ¼r den kompletten Rollback.
+interaction.command.rollback.sub.full.arg.reason=Der Grund für den kompletten Rollback.
 interaction.command.rollback.sub.timed.description=Markiert den Rollback als einen zeitlich begrenzten Rollback.
-interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurÃ¼ckgesetzt werden soll.
+interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurückgesetzt werden soll.
 ## Tickets
 ticket.open.success=Dein "{0}"-Ticket wurde erfolgreich erstellt!
 # Ticket Button
 interaction.command.ticket.ticket-button.title=Ticket erstellen
-interaction.command.ticket.ticket-button.description=Du mÃ¶chtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag fÃ¼r den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
+interaction.command.ticket.ticket-button.description=Du möchtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag für den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
 \n\
 Bitte mache dich **vorher** mit unterschiedlichen Tickettypen vertraut!\n\
-Die Ãœbersicht findest du hier: https://server.castcrafter.de/support\n\
+Die Übersicht findest du hier: https://server.castcrafter.de/support\n\
 \n\
-Allgemeine Fragen sollten in den dafÃ¼r vorgesehenen Ã¶ffentlichen KanÃ¤len gestellt werden.\n\
+Allgemeine Fragen sollten in den dafür vorgesehenen öffentlichen Kanälen gestellt werden.\n\
 \n\
-Wir bemÃ¼hen uns die Tickets schnellstmÃ¶glich zu bearbeiten.\
-  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets lÃ¤nger dauern kann.
+Wir bemühen uns die Tickets schnellstmöglich zu bearbeiten.\
+  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets länger dauern kann.
 # Ticket Close
-interaction.command.ticket.close.arg.reason=Der Grund fÃ¼r das SchlieÃŸen des Tickets
-interaction.command.ticket.close.closing=SchlieÃŸe Ticket...
+interaction.command.ticket.close.arg.reason=Der Grund für das Schließen des Tickets
+interaction.command.ticket.close.closing=Schließe Ticket...
 # Ticket Dependencies not met
-interaction.command.ticket.dependencies-not-met.close-reason=Du erfÃ¼llst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket erÃ¶ffnest.
+interaction.command.ticket.dependencies-not-met.close-reason=Du erfüllst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket eröffnest.
 # Ticket member add
-interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefÃ¼gt werden soll
-interaction.command.ticket.member.add.adding=HinzufÃ¼gen...
-interaction.command.ticket.member.add.checking-bot=ÃœberprÃ¼fe, ob der Bot hinzugefÃ¼gt werden soll...
-interaction.command.ticket.member.add.checking-already-in-ticket=ÃœberprÃ¼fe, ob der Nutzer bereits im Ticket ist...
-interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefÃ¼gt.
+interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefügt werden soll
+interaction.command.ticket.member.add.adding=Hinzufügen...
+interaction.command.ticket.member.add.checking-bot=Überprüfe, ob der Bot hinzugefügt werden soll...
+interaction.command.ticket.member.add.checking-already-in-ticket=Überprüfe, ob der Nutzer bereits im Ticket ist...
+interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefügt.
 interaction.command.ticket.member.embed.title=Willkommen im Ticket!
-interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefÃ¼gt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
-interaction.command.ticket.member.embed.footer=HinzugefÃ¼gt von {0}
+interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefügt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
+interaction.command.ticket.member.embed.footer=Hinzugefügt von {0}
 # Ticket member remove
 interaction.command.ticket.member.remove.arg.member=Der Benutzer, der entfernt werden soll
 interaction.command.ticket.member.remove.removing=Entferne...
 interaction.command.ticket.member.remove.removed=Der Nutzer wurde erfolgreich entfernt.
-interaction.command.ticket.member.remove.checking-bot=ÃœberprÃ¼fe, ob der Bot entfernt werden soll...
-interaction.command.ticket.member.remove.checking-in-ticket=ÃœberprÃ¼fe, ob der Nutzer im Ticket ist...
+interaction.command.ticket.member.remove.checking-bot=Überprüfe, ob der Bot entfernt werden soll...
+interaction.command.ticket.member.remove.checking-in-ticket=Überprüfe, ob der Nutzer im Ticket ist...
 interaction.command.ticket.member.remove.announcement={0} wurde von {1} aus dem Ticket entfernt.
 interaction.command.ticket.member.remove.error=Der Nutzer konnte nicht entfernt werden.
 # Whitelist
-interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefÃ¼gt werden soll.
+interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefügt werden soll.
 interaction.command.ticket.whitelist.arg.minecraft-name=Der Minecraft-Name des Spielers
 interaction.command.ticket.whitelist.arg.twitch-name=Der Twitch-Name des Spielers
 interaction.command.ticket.whitelist.uuid-fetching=UUID wird abgerufen...
-interaction.command.ticket.whitelist.checking=ÃœberprÃ¼fe auf vorhandene Whitelists...
-interaction.command.ticket.whitelist.adding=FÃ¼ge zur Whitelist hinzu...
-interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefÃ¼gt...
+interaction.command.ticket.whitelist.checking=Überprüfe auf vorhandene Whitelists...
+interaction.command.ticket.whitelist.adding=Füge zur Whitelist hinzu...
+interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefügt...
 interaction.command.ticket.whitelist.already-whitelisted=Der Spieler befindet sich bereits auf der Whitelist.
 interaction.command.ticket.whitelist.added={0} befindet sich nun auf der Whitelist.
 interaction.command.ticket.wlquery.querying=Frage Whitelist Informationen ab...
@@ -85,10 +85,10 @@ interaction.command.ticket.whitelist.role.remove.failed={0} Benutzer konnten nic
 # Missing information
 interaction.command.ticket.missing-information.arg.user=Der Benutzer, der die Nachricht erhalten soll.
 interaction.command.ticket.missing-information.message.title=Fehlende Informationen
-interaction.command.ticket.missing-information.message.content=Vielen Dank fÃ¼r deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu kÃ¶nnen.\n\
+interaction.command.ticket.missing-information.message.content=Vielen Dank für deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu können.\n\
   Bitte stelle sicher, dass du die folgenden Punkte bereitstellst:\n\n\
   - **Genaue Koordinaten**, z. B. `110 64 60` (Standort eines Containers)\n\
-  - **Dimension**, z.Â B. *Nether*\n\
+  - **Dimension**, z. B. *Nether*\n\
   - **Beschreibung** des Problems\n\
   - **Server**, auf dem der Fehler aufgetreten ist
 # Whitelist
@@ -97,46 +97,46 @@ modal.whitelist.step.twitch.question.yes=Ja, ich habe meinen Twitch-Account verb
 modal.whitelist.step.twitch.question.no=Nein, ich habe meinen Twitch-Account nicht verbunden oder folge CastCrafter nicht auf Twitch.
 modal.whitelist.step.twitch.error.not-connected=Du hast deinen Twitch-Account nicht mit Discord verbunden.
 modal.whitelist.step.minecraft.label=Minecraft Name
-modal.whitelist.step.minecraft.invalid=Du musst einen gÃ¼ltigen Minecraft-Java Namen angeben.
+modal.whitelist.step.minecraft.invalid=Du musst einen gültigen Minecraft-Java Namen angeben.
 modal.whitelist.step.minecraft.already-whitelisted=Du bist bereits auf der Whitelist.
 modal.whitelist.step.minecraft.open=> Minecraft Name: ```{0}```\n\n\
-Vielen Dank fÃ¼r deine Whitelist Anfrage. \
-Du wirst nun auf die Whitelist hinzugefÃ¼gt, sobald jemand aus dem Team Zeit findet. \
+Vielen Dank für deine Whitelist Anfrage. \
+Du wirst nun auf die Whitelist hinzugefügt, sobald jemand aus dem Team Zeit findet. \
 Wir bitten um etwas Geduld.
 modal.whitelist.title=Whitelist Ticket
-modal.whitelist.description=Whitelist Anfrage fÃ¼r den Survival Server
+modal.whitelist.description=Whitelist Anfrage für den Survival Server
 # Report
 modal.report.step.selection.griefing.title=Auf welchem Server wurdest du gegrieft?
 modal.report.step.selection.griefing.survival1.label=Survival 01
 modal.report.step.selection.griefing.survival2.label=Survival 02
-modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wÃ¤hle diese Option!
+modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wähle diese Option!
 modal.report.step.selection.griefing.event.label=Event
-modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wÃ¤hle diese Option!
+modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wähle diese Option!
 modal.report.step.griefing.input.world.label=Welt
 modal.report.step.griefing.input.world.placeholder=overworld
 modal.report.step.griefing.input.xyz.label=X Y Z
 modal.report.step.griefing.input.xyz.placeholder=123 64 321
 modal.report.step.griefing.input.what-griefed.label=Was wurde gegrieft?
-modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschÃ¤digten Strukturen oder gestohlenen GegenstÃ¤nde.
-modal.report.step.griefing.input.additional-info.label=ZusÃ¤tzliche Informationen
-modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen mÃ¶chtest?
+modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschädigten Strukturen oder gestohlenen Gegenstände.
+modal.report.step.griefing.input.additional-info.label=Zusätzliche Informationen
+modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen möchtest?
 modal.report.step.griefing.messages.server=> Server: `{0}`
 modal.report.step.griefing.messages.location=> Location: `{0}` - `{1}`
 modal.report.step.player.input.reporting-player.label=Dein Spielname
 modal.report.step.player.input.reason.label=Grund
 modal.report.step.player.input.reason.placeholder=Was hat der Spielende getan?
 modal.report.step.player.messages.reporting-player=> Meldender Spielende: `{0}`
-modal.report.step.type.selection.title=MÃ¶chtest du Griefing oder einen Spieler Melden?
+modal.report.step.type.selection.title=Möchtest du Griefing oder einen Spieler Melden?
 modal.report.step.type.selection.griefing.label=Griefing
-modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wÃ¤hle diese Option!
+modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wähle diese Option!
 modal.report.step.type.selection.player.label=Spieler
-modal.report.step.type.selection.player.description=Du mÃ¶chtest einen Spieler melden? Dann wÃ¤hle diese Option!
+modal.report.step.type.selection.player.description=Du möchtest einen Spieler melden? Dann wähle diese Option!
 modal.report.step.type.input.griefing.own-name=Dein Spielername
 modal.report.step.type.input.report.reported-player=Zu meldender Spielername
 modal.report.step.type.messages.player-name=> Spielername: `{0}`
 modal.report.title=Report
-modal.report.description=Melde Griefing, Cheating oder andere RegelverstÃ¶ÃŸe.
-modal.report.message=Danke fÃ¼r deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir den Vorfall untersuchen.
+modal.report.description=Melde Griefing, Cheating oder andere Regelverstöße.
+modal.report.message=Danke für deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir den Vorfall untersuchen.
 # Unban
 modal.unban.step.type.selection.title=Wurdest du wegen `Unerlaubte Clientmodifikationen` gebannt?
 modal.unban.step.type.selection.yes.label=Ja
@@ -148,25 +148,25 @@ modal.unban.step.punishment-id.input.placeholder=Deine Punishment ID
 modal.unban.step.punishment-id.messages.punishment-id=> Punishment ID: ``{0}``
 modal.unban.step.punishment-id.error.invalid=Es konnte kein Ausschluss mit der eingegebenen ID gefunden werden!
 modal.unban.step.appeal.input.appeal.label=Dein Entbannungsantrag
-modal.unban.step.appeal.input.appeal.placeholder=ErklÃ¤re, warum du entbannt werden mÃ¶chtest und was du aus deinem Verhalten gelernt hast.
+modal.unban.step.appeal.input.appeal.placeholder=Erkläre, warum du entbannt werden möchtest und was du aus deinem Verhalten gelernt hast.
 modal.unban.step.appeal.messages.appeal.title=# Entbannungsantrag
 modal.unban.step.appeal.messages.appeal=> {0}
 modal.unban.step.modlist.input.label=Modifikationsliste
 modal.unban.step.modlist.input.placeholder=Bitte gebe hier AUSNAHMSLOS ALLE Modifikationen an, die du benutzt hast! (Screenshot / Liste)
 modal.unban.step.modlist.messages.open=> Modifikationsliste: [{0}]
 modal.unban.title=Entbannungsantrag
-modal.unban.description=EntbannungsantrÃ¤ge fÃ¼r den Community Server
-modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von EntbannungsantrÃ¤gen wÃ¤hrend laufender Events **bis zu 24 Stunden** dauern kann!
+modal.unban.description=Entbannungsanträge für den Community Server
+modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von Entbannungsanträgen während laufender Events **bis zu 24 Stunden** dauern kann!
 # Bug Report
 modal.bug-report.title=Bug Report
 modal.bug-report.description=Fehler gefunden? Melde ihn hier.
-modal.bug-report.message=Danke fÃ¼r deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern.\
-  \ Bitte hab etwas Geduld, wÃ¤hrend wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
-  \ die den Fehler zeigen, fÃ¼ge diese bitte hinzu.
+modal.bug-report.message=Danke für deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kümmern.\
+  \ Bitte hab etwas Geduld, während wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
+  \ die den Fehler zeigen, füge diese bitte hinzu.
 modal.bug-report.step.minecraft.label=Minecraft Name
 modal.bug-report.step.minecraft.messages.minecraft-name=> Minecraft Name: `{0}`
-modal.bug-report.step.report.label=Welchen Bug mÃ¶chtest du melden?
-modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie mÃ¶glich.
+modal.bug-report.step.report.label=Welchen Bug möchtest du melden?
+modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie möglich.
 modal.bug-report.step.report.message.title=# Bug Report
 # Minecraft Support
 modal.minecraft-support.minecraft-name.label=Minecraft Name
@@ -174,116 +174,115 @@ modal.minecraft-support.minecraft-name.placeholder=Dein Minecraft Name
 modal.minecraft-support.minecraft-name.message=> Minecraft Name: `{0}`
 # Common support
 modal.support.step.input.label=Dein Anliegen
-modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie mÃ¶glich.
+modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie möglich.
 modal.support.step.input.message=# Anliegen
 # Survival support
 modal.support.survival.titel=Survival Support
-modal.support.survival.description=Anliegen bezÃ¼glich des Survival Servers
-modal.support.survival.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
+modal.support.survival.description=Anliegen bezüglich des Survival Servers
+modal.support.survival.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
 # Event support
 modal.support.event.titel=Event Support
-modal.support.event.description=Anliegen bezÃ¼glich des Event Servers
-modal.support.event.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
+modal.support.event.description=Anliegen bezüglich des Event Servers
+modal.support.event.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
 # Discord support
 modal.support.discord.titel=Discord Support
-modal.support.discord.description=Anliegen bezÃ¼glich des Discord Servers
-modal.support.discord.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
+modal.support.discord.description=Anliegen bezüglich des Discord Servers
+modal.support.discord.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
 ### Errors
 error.generic=Ein Fehler ist aufgetreten.
 error.no-guild=Du musst dich auf einem Server befinden!
 error.server-not-registered=Dieser Server ist nicht registriert!
-error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszufÃ¼hren!
-error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszufÃ¼hren.
+error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszuführen!
+error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszuführen.
 error.command.arg.missing.user=Du musst einen Benutzer angeben.
 error.command.arg.missing.role=Du musst eine Rolle angeben.
 error.command.arg.missing.number=Du musst eine Zahl angeben.
 error.command.arg.missing.boolean=Du musst einen Wahrheitswert angeben.
 error.command.arg.missing.string=Du musst einen Text angeben.
 error.command.arg.missing.attachment=Du musst eine Anlage angeben.
-error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszufÃ¼hren!
-error.ticket.close=Es ist ein Fehler beim SchlieÃŸen des Tickets aufgetreten.
+error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszuführen!
+error.ticket.close=Es ist ein Fehler beim Schließen des Tickets aufgetreten.
 error.ticket.close.not-found=Das Ticket konnte nicht gefunden werden.
 error.ticket.close.not-closable=Der Ticket-Channel kann nicht geschlossen werden.
 error.ticket.close.already-closing=Das Ticket wird bereits geschlossen.
 error.ticket.close.already-closed=Das Ticket ist bereits geschlossen.
-error.ticket.bot.add=Du kannst den Bot nicht hinzufÃ¼gen.
+error.ticket.bot.add=Du kannst den Bot nicht hinzufügen.
 error.ticket.bot.remove=Du kannst den Bot nicht entfernen.
 error.ticket.member.already-in-ticket=Dieser Nutzer ist bereits in diesem Ticket.
 error.ticket.member.not-in-ticket=Dieser Nutzer ist nicht in diesem Ticket.
-error.ticket.add.member=Der Nutzer konnte nicht hinzugefÃ¼gt werden.
+error.ticket.add.member=Der Nutzer konnte nicht hinzugefügt werden.
 error.ticket.remove.member=Der Nutzer konnte nicht entfernt werden.
 error.minecraft.not-found=Der Spieler konnte nicht gefunden werden.
 error.ticket.whitelist=Es ist ein Fehler aufgetreten. Die Whitelist konnte nicht erstellt werden.
 error.ticket.wlquery.no-user=Es wurde kein Benutzer angegeben.
-error.whitelist.query.no-results=Es wurden keine Whitelist EintrÃ¤ge fÃ¼r `{0}` gefunden.
+error.whitelist.query.no-results=Es wurden keine Whitelist Einträge für `{0}` gefunden.
 error.whitelist.role-not-registered=Die Whitelist Rolle ist nicht registriert.
 error.whitelist.change.not-whitelisted=Der Spieler ist nicht auf der Whitelist.
-error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geÃ¶ffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
-error.ticket.permission.open=Du hast nicht die benÃ¶tigten Berechtigungen, um ein Ticket zu erstellen!
+error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geöffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
+error.ticket.permission.open=Du hast nicht die benötigten Berechtigungen, um ein Ticket zu erstellen!
 error.ticket.whitelist.not-whitelisted=Du musst auf der Whitelist sein, um dieses Ticket zu erstellen.
 error.ticket.whitelist.already-whitelisted=Du bist bereits auf der Whitelist und kannst dieses Ticket nicht erstellen.
-error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknÃ¼pfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
-error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht Ã¶ffentlich. Bitte stelle sicher, dass dein Profil Ã¶ffentlich ist, damit wir deine VerknÃ¼pfung Ã¼berprÃ¼fen kÃ¶nnen.
+error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknüpfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
+error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht öffentlich. Bitte stelle sicher, dass dein Profil öffentlich ist, damit wir deine Verknüpfung überprüfen können.
 ## Misc
-# DonÂ´t ask to ask
+# Don´t ask to ask
 command.dontasktoask.message.title=Frag einfach direkt.
 command.dontasktoask.message.content=Wenn du eine Frage hast, stell sie einfach. Suche nicht nach \
   bestimmten Personen oder Experten. Frage nicht, ob du eine Frage stellen darfst oder ob jemand \
-  wach oder verfÃ¼gbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
+  wach oder verfügbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
 # How to join
 command.howtojoin.arg.user.description=Der Benutzer, der die Anleitung erhalten soll.
 command.howtojoin.message.title=Wie kannst du den CastCrafter-Server betreten?
-command.howtojoin.message.content=MÃ¶chtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
+command.howtojoin.message.content=Möchtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
   - Schau dir unsere Anleitung hier an: [Anleitung zum Beitreten](https://server.castcrafter.de/how-to-join)\n\
-  - Du brauchst keine Whitelist fÃ¼r den Event-Server.\n\
-  - FÃ¼r den Survival-Server brauchst du eine Whitelist.\n\n\
+  - Du brauchst keine Whitelist für den Event-Server.\n\
+  - Für den Survival-Server brauchst du eine Whitelist.\n\n\
    -# Wir freuen uns, dich bald auf dem Server zu sehen!
 # FAQ
 command.faq.arg.question=Die Frage, die beantwortet werden soll.
 command.faq.arg.user=Der Benutzer, der die Antwort erhalten soll.
-command.faq.questions.connect-twitch-with-discord=Wie verknÃ¼pfe ich meinen Twitch Account mit Discord?
-command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknÃ¼pfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
+command.faq.questions.connect-twitch-with-discord=Wie verknüpfe ich meinen Twitch Account mit Discord?
+command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknüpfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
 command.faq.questions.banned=Ich wurde gebannt. Was kann ich tun?
 command.faq.questions.banned.answer=Wenn du denkst, dir ist mit einem Ausschluss vom Server unrecht getan, erstelle einen [Entbannungsantrag](https://server.castcrafter.de/support#unban-ticket)!
-command.faq.questions.event=Wann findet das nÃ¤chste Event statt?
-command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekÃ¼ndigt.
+command.faq.questions.event=Wann findet das nächste Event statt?
+command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekündigt.
 command.faq.questions.open-ticket=Wie erstelle ich ein Ticket?
 command.faq.questions.open-ticket.answer=Eine Anleitung, wie du ein Ticket erstellen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/support.html)
 command.faq.questions.rulebook=Regelwerk
 command.faq.questions.rulebook.answer=Alle Regeln, die auf dem Server gelten, findest du hier: \
   [Regelwerk](https://server.castcrafter.de/rules)\n\n\
-  Bitte lies die Regeln sorgfÃ¤ltig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
-  -# Bei Events **kÃ¶nnen** die Regeln abweichen. \
-  Diese Ã„nderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
+  Bitte lies die Regeln sorgfältig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
+  -# Bei Events **können** die Regeln abweichen. \
+  Diese Änderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
 command.faq.questions.server-modpack=Offizielles Server Modpack
 command.faq.questions.server-modpack.answer=Um das Spielerlebnis auf dem Server zu optimieren \
-  gibt es ein offizielles Modpack, welches ausschlieÃŸlich getestete Modifikationen enthÃ¤lt. \
+  gibt es ein offizielles Modpack, welches ausschließlich getestete Modifikationen enthält. \
   Alle enthaltenen Mods sind erlaubt und mit dem Server kompatibel.\n\
-  **Das Modpack kÃ¶nnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
-  -# **Ã„nderungen am Modpack oder das HinzufÃ¼gen zusÃ¤tzlicher Mods kÃ¶nnen zu InkompatibilitÃ¤ten und \
-  unter UmstÃ¤nden zu einem Ausschluss des Servers fÃ¼hren. \
-  Wir Ã¼bernehmen keine Verantwortung fÃ¼r modifizierte Versionen des Modpacks.**
+  **Das Modpack könnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
+  -# **Änderungen am Modpack oder das Hinzufügen zusätzlicher Mods können zu Inkompatibilitäten und \
+  unter Umständen zu einem Ausschluss des Servers führen. \
+  Wir übernehmen keine Verantwortung für modifizierte Versionen des Modpacks.**
 command.faq.questions.problem-ressourcepack=Probleme mit dem Ressourcenpaket
-command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket lÃ¤d nicht richtig oder du \
-  erhÃ¤ltst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
+command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket läd nicht richtig oder du \
+  erhältst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
   Hier findest du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#resourcepack-issues)
 command.faq.questions.problem-connection=Verbindungsprobleme / Netzwerk Lags
 command.faq.questions.problem-connection.answer=Du kannst dich nicht mit dem Server verbinden, \
-  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmÃ¤ÃŸig starke Lags?\n\
+  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmäßig starke Lags?\n\
   Hier findet du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#connection-issues)
 command.faq.questions.read-the-docs=Dokumentation
-command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausfÃ¼hrlichen \
+command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausführlichen \
   Dokumentation beantwortet: [Dokumentation](https://server.castcrafter.de/community-server-landing-page)\n\n\
-  FÃ¼r detaillierte Anleitungen, Tipps und hÃ¤ufig gestellte Fragen besuche den obigen Link.
+  Für detaillierte Anleitungen, Tipps und häufig gestellte Fragen besuche den obigen Link.
 command.faq.questions.maintenance=Wartungsarbeiten
 command.faq.questions.maintenance.answer=Aktuell finden Wartungsarbeiten statt. \
-  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal und \
-  in der [Dokumentation](https://server.castcrafter.de/current-server-issues.html#server-lockdown).
+  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal.
 ### Menus
 ## Tickets menu
-menu.ticket.select.placeholder=Ticket auswÃ¤hlen
+menu.ticket.select.placeholder=Ticket auswählen
 ### Other
 # Whitelist
 whitelist.query.embed.title=Whitelist Query
@@ -292,12 +291,12 @@ whitelist.query.embed.description=Whitelist Informationen
 whitelist.query.embed.field.minecraft-name=Minecraft Name
 whitelist.query.embed.field.twitch-name=Twitch Link
 whitelist.query.embed.field.discord-user=Discord User
-whitelist.query.embed.field.added-by=HinzugefÃ¼gt von
+whitelist.query.embed.field.added-by=Hinzugefügt von
 whitelist.query.embed.field.uuid=UUID
 whitelist.query.embed.field.blocked=Blockiert
-whitelist.query.start=WlQuery fÃ¼r: `{0}`
+whitelist.query.start=WlQuery für: `{0}`
 # Tickets
-ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von InaktivitÃ¤t automatisch geschlossen.
+ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von Inaktivität automatisch geschlossen.
 # Common
 common.yes=Ja
 common.no=Nein

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,68 +1,68 @@
 ### Interactions
 ## Show Admin Panel
 interaction.context.menu.admin-panel.button=Open Admin Panel
-interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r den Benutzer {0} zu Ã¶ffnen.
-interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-EintrÃ¤ge fÃ¼r diesen Benutzer gefunden. Daher kÃ¶nnen wir den Link zum Admin-Panel nicht Ã¶ffnen.
+interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für den Benutzer {0} zu öffnen.
+interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-Einträge für diesen Benutzer gefunden. Daher können wir den Link zum Admin-Panel nicht öffnen.
 interaction.context.menu.admin-panel.no-private-message-allowed=Du hast private Nachrichten deaktiviert oder der Bot darf dir keine Nachrichten senden.
 interaction.context.menu.ticket-admin-panel.not-a-thread=Dieser Befehl kann nur in einem Thread-Kanal verwendet werden.
 interaction.context.menu.ticket-admin-panel.not-a-ticket=Dieser Befehl kann nur in einem Ticket-Thread verwendet werden.
-interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r das Ticket {0} zu Ã¶ffnen.
+interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für das Ticket {0} zu öffnen.
 ## Open Ticket
-interaction.button.open-ticket.title=Ticket Typ auswÃ¤hlen
-interaction.button.open-ticket.description=Bitte wÃ¤hle das passende Ticket aus, welches du Ã¶ffnen mÃ¶chtest.\n\
+interaction.button.open-ticket.title=Ticket Typ auswählen
+interaction.button.open-ticket.description=Bitte wähle das passende Ticket aus, welches du öffnen möchtest.\n\
 \n\
 Informationen zu den unterschiedlichen Tickettypen findest du auf https://server.castcrafter.de/support
 ### Commands
 # Request Rollback
-interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurÃ¼ckgesetzt werden sollen.
-interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurÃ¼ckgesetzt werden sollen.
+interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurückgesetzt werden sollen.
+interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurückgesetzt werden sollen.
 interaction.command.rollback.sub.full.description=Markiert den Rollback als einen kompletten Rollback.
-interaction.command.rollback.sub.full.arg.reason=Der Grund fÃ¼r den kompletten Rollback.
+interaction.command.rollback.sub.full.arg.reason=Der Grund für den kompletten Rollback.
 interaction.command.rollback.sub.timed.description=Markiert den Rollback als einen zeitlich begrenzten Rollback.
-interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurÃ¼ckgesetzt werden soll.
+interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurückgesetzt werden soll.
 ## Tickets
 ticket.open.success=Dein "{0}"-Ticket wurde erfolgreich erstellt!
 # Ticket Button
 interaction.command.ticket.ticket-button.title=Ticket erstellen
-interaction.command.ticket.ticket-button.description=Du mÃ¶chtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag fÃ¼r den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
+interaction.command.ticket.ticket-button.description=Du möchtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag für den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
 \n\
 Bitte mache dich **vorher** mit unterschiedlichen Tickettypen vertraut!\n\
-Die Ãœbersicht findest du hier: https://server.castcrafter.de/support\n\
+Die Übersicht findest du hier: https://server.castcrafter.de/support\n\
 \n\
-Allgemeine Fragen sollten in den dafÃ¼r vorgesehenen Ã¶ffentlichen KanÃ¤len gestellt werden.\n\
+Allgemeine Fragen sollten in den dafür vorgesehenen öffentlichen Kanälen gestellt werden.\n\
 \n\
-Wir bemÃ¼hen uns die Tickets schnellstmÃ¶glich zu bearbeiten.\
-  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets lÃ¤nger dauern kann.
+Wir bemühen uns die Tickets schnellstmöglich zu bearbeiten.\
+  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets länger dauern kann.
 # Ticket Close
-interaction.command.ticket.close.arg.reason=Der Grund fÃ¼r das SchlieÃŸen des Tickets
-interaction.command.ticket.close.closing=SchlieÃŸe Ticket...
+interaction.command.ticket.close.arg.reason=Der Grund für das Schließen des Tickets
+interaction.command.ticket.close.closing=Schließe Ticket...
 # Ticket Dependencies not met
-interaction.command.ticket.dependencies-not-met.close-reason=Du erfÃ¼llst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket erÃ¶ffnest.
+interaction.command.ticket.dependencies-not-met.close-reason=Du erfüllst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket eröffnest.
 # Ticket member add
-interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefÃ¼gt werden soll
-interaction.command.ticket.member.add.adding=HinzufÃ¼gen...
-interaction.command.ticket.member.add.checking-bot=ÃœberprÃ¼fe, ob der Bot hinzugefÃ¼gt werden soll...
-interaction.command.ticket.member.add.checking-already-in-ticket=ÃœberprÃ¼fe, ob der Nutzer bereits im Ticket ist...
-interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefÃ¼gt.
+interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefügt werden soll
+interaction.command.ticket.member.add.adding=Hinzufügen...
+interaction.command.ticket.member.add.checking-bot=Überprüfe, ob der Bot hinzugefügt werden soll...
+interaction.command.ticket.member.add.checking-already-in-ticket=Überprüfe, ob der Nutzer bereits im Ticket ist...
+interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefügt.
 interaction.command.ticket.member.embed.title=Willkommen im Ticket!
-interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefÃ¼gt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
-interaction.command.ticket.member.embed.footer=HinzugefÃ¼gt von {0}
+interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefügt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
+interaction.command.ticket.member.embed.footer=Hinzugefügt von {0}
 # Ticket member remove
 interaction.command.ticket.member.remove.arg.member=Der Benutzer, der entfernt werden soll
 interaction.command.ticket.member.remove.removing=Entferne...
 interaction.command.ticket.member.remove.removed=Der Nutzer wurde erfolgreich entfernt.
-interaction.command.ticket.member.remove.checking-bot=ÃœberprÃ¼fe, ob der Bot entfernt werden soll...
-interaction.command.ticket.member.remove.checking-in-ticket=ÃœberprÃ¼fe, ob der Nutzer im Ticket ist...
+interaction.command.ticket.member.remove.checking-bot=Überprüfe, ob der Bot entfernt werden soll...
+interaction.command.ticket.member.remove.checking-in-ticket=Überprüfe, ob der Nutzer im Ticket ist...
 interaction.command.ticket.member.remove.announcement={0} wurde von {1} aus dem Ticket entfernt.
 interaction.command.ticket.member.remove.error=Der Nutzer konnte nicht entfernt werden.
 # Whitelist
-interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefÃ¼gt werden soll.
+interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefügt werden soll.
 interaction.command.ticket.whitelist.arg.minecraft-name=Der Minecraft-Name des Spielers
 interaction.command.ticket.whitelist.arg.twitch-name=Der Twitch-Name des Spielers
 interaction.command.ticket.whitelist.uuid-fetching=UUID wird abgerufen...
-interaction.command.ticket.whitelist.checking=ÃœberprÃ¼fe auf vorhandene Whitelists...
-interaction.command.ticket.whitelist.adding=FÃ¼ge zur Whitelist hinzu...
-interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefÃ¼gt...
+interaction.command.ticket.whitelist.checking=Überprüfe auf vorhandene Whitelists...
+interaction.command.ticket.whitelist.adding=Füge zur Whitelist hinzu...
+interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefügt...
 interaction.command.ticket.whitelist.already-whitelisted=Der Spieler befindet sich bereits auf der Whitelist.
 interaction.command.ticket.whitelist.added={0} befindet sich nun auf der Whitelist.
 interaction.command.ticket.wlquery.querying=Frage Whitelist Informationen ab...
@@ -85,10 +85,10 @@ interaction.command.ticket.whitelist.role.remove.failed={0} Benutzer konnten nic
 # Missing information
 interaction.command.ticket.missing-information.arg.user=Der Benutzer, der die Nachricht erhalten soll.
 interaction.command.ticket.missing-information.message.title=Fehlende Informationen
-interaction.command.ticket.missing-information.message.content=Vielen Dank fÃ¼r deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu kÃ¶nnen.\n\
+interaction.command.ticket.missing-information.message.content=Vielen Dank für deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu können.\n\
   Bitte stelle sicher, dass du die folgenden Punkte bereitstellst:\n\n\
   - **Genaue Koordinaten**, z. B. `110 64 60` (Standort eines Containers)\n\
-  - **Dimension**, z.Â B. *Nether*\n\
+  - **Dimension**, z. B. *Nether*\n\
   - **Beschreibung** des Problems\n\
   - **Server**, auf dem der Fehler aufgetreten ist
 # Whitelist
@@ -97,46 +97,46 @@ modal.whitelist.step.twitch.question.yes=Ja, ich habe meinen Twitch-Account verb
 modal.whitelist.step.twitch.question.no=Nein, ich habe meinen Twitch-Account nicht verbunden oder folge CastCrafter nicht auf Twitch.
 modal.whitelist.step.twitch.error.not-connected=Du hast deinen Twitch-Account nicht mit Discord verbunden.
 modal.whitelist.step.minecraft.label=Minecraft Name
-modal.whitelist.step.minecraft.invalid=Du musst einen gÃ¼ltigen Minecraft-Java Namen angeben.
+modal.whitelist.step.minecraft.invalid=Du musst einen gültigen Minecraft-Java Namen angeben.
 modal.whitelist.step.minecraft.already-whitelisted=Du bist bereits auf der Whitelist.
 modal.whitelist.step.minecraft.open=> Minecraft Name: ```{0}```\n\n\
-Vielen Dank fÃ¼r deine Whitelist Anfrage. \
-Du wirst nun auf die Whitelist hinzugefÃ¼gt, sobald jemand aus dem Team Zeit findet. \
+Vielen Dank für deine Whitelist Anfrage. \
+Du wirst nun auf die Whitelist hinzugefügt, sobald jemand aus dem Team Zeit findet. \
 Wir bitten um etwas Geduld.
 modal.whitelist.title=Whitelist Ticket
-modal.whitelist.description=Whitelist Anfrage fÃ¼r den Survival Server
+modal.whitelist.description=Whitelist Anfrage für den Survival Server
 # Report
 modal.report.step.selection.griefing.title=Auf welchem Server wurdest du gegrieft?
 modal.report.step.selection.griefing.survival1.label=Survival 01
 modal.report.step.selection.griefing.survival2.label=Survival 02
-modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wÃ¤hle diese Option!
+modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wähle diese Option!
 modal.report.step.selection.griefing.event.label=Event
-modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wÃ¤hle diese Option!
+modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wähle diese Option!
 modal.report.step.griefing.input.world.label=Welt
 modal.report.step.griefing.input.world.placeholder=overworld
 modal.report.step.griefing.input.xyz.label=X Y Z
 modal.report.step.griefing.input.xyz.placeholder=123 64 321
 modal.report.step.griefing.input.what-griefed.label=Was wurde gegrieft?
-modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschÃ¤digten Strukturen oder gestohlenen GegenstÃ¤nde.
-modal.report.step.griefing.input.additional-info.label=ZusÃ¤tzliche Informationen
-modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen mÃ¶chtest?
+modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschädigten Strukturen oder gestohlenen Gegenstände.
+modal.report.step.griefing.input.additional-info.label=Zusätzliche Informationen
+modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen möchtest?
 modal.report.step.griefing.messages.server=> Server: `{0}`
 modal.report.step.griefing.messages.location=> Location: `{0}` - `{1}`
 modal.report.step.player.input.reporting-player.label=Dein Spielname
 modal.report.step.player.input.reason.label=Grund
 modal.report.step.player.input.reason.placeholder=Was hat der Spielende getan?
 modal.report.step.player.messages.reporting-player=> Meldender Spielende: `{0}`
-modal.report.step.type.selection.title=MÃ¶chtest du Griefing oder einen Spieler Melden?
+modal.report.step.type.selection.title=Möchtest du Griefing oder einen Spieler Melden?
 modal.report.step.type.selection.griefing.label=Griefing
-modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wÃ¤hle diese Option!
+modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wähle diese Option!
 modal.report.step.type.selection.player.label=Spieler
-modal.report.step.type.selection.player.description=Du mÃ¶chtest einen Spieler melden? Dann wÃ¤hle diese Option!
+modal.report.step.type.selection.player.description=Du möchtest einen Spieler melden? Dann wähle diese Option!
 modal.report.step.type.input.griefing.own-name=Dein Spielername
 modal.report.step.type.input.report.reported-player=Zu meldender Spielername
 modal.report.step.type.messages.player-name=> Spielername: `{0}`
 modal.report.title=Report
-modal.report.description=Melde Griefing, Cheating oder andere RegelverstÃ¶ÃŸe.
-modal.report.message=Danke fÃ¼r deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir den Vorfall untersuchen.
+modal.report.description=Melde Griefing, Cheating oder andere Regelverstöße.
+modal.report.message=Danke für deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir den Vorfall untersuchen.
 # Unban
 modal.unban.step.type.selection.title=Wurdest du wegen `Unerlaubte Clientmodifikationen` gebannt?
 modal.unban.step.type.selection.yes.label=Ja
@@ -148,25 +148,25 @@ modal.unban.step.punishment-id.input.placeholder=Deine Punishment ID
 modal.unban.step.punishment-id.messages.punishment-id=> Punishment ID: ``{0}``
 modal.unban.step.punishment-id.error.invalid=Es konnte kein Ausschluss mit der eingegebenen ID gefunden werden!
 modal.unban.step.appeal.input.appeal.label=Dein Entbannungsantrag
-modal.unban.step.appeal.input.appeal.placeholder=ErklÃ¤re, warum du entbannt werden mÃ¶chtest und was du aus deinem Verhalten gelernt hast.
+modal.unban.step.appeal.input.appeal.placeholder=Erkläre, warum du entbannt werden möchtest und was du aus deinem Verhalten gelernt hast.
 modal.unban.step.appeal.messages.appeal.title=# Entbannungsantrag
 modal.unban.step.appeal.messages.appeal=> {0}
 modal.unban.step.modlist.input.label=Modifikationsliste
 modal.unban.step.modlist.input.placeholder=Bitte gebe hier AUSNAHMSLOS ALLE Modifikationen an, die du benutzt hast! (Screenshot / Liste)
 modal.unban.step.modlist.messages.open=> Modifikationsliste: [{0}]
 modal.unban.title=Entbannungsantrag
-modal.unban.description=EntbannungsantrÃ¤ge fÃ¼r den Community Server
-modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von EntbannungsantrÃ¤gen wÃ¤hrend laufender Events **bis zu 24 Stunden** dauern kann!
+modal.unban.description=Entbannungsanträge für den Community Server
+modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von Entbannungsanträgen während laufender Events **bis zu 24 Stunden** dauern kann!
 # Bug Report
 modal.bug-report.title=Bug Report
 modal.bug-report.description=Fehler gefunden? Melde ihn hier.
-modal.bug-report.message=Danke fÃ¼r deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern.\
-  \ Bitte hab etwas Geduld, wÃ¤hrend wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
-  \ die den Fehler zeigen, fÃ¼ge diese bitte hinzu.
+modal.bug-report.message=Danke für deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kümmern.\
+  \ Bitte hab etwas Geduld, während wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
+  \ die den Fehler zeigen, füge diese bitte hinzu.
 modal.bug-report.step.minecraft.label=Minecraft Name
 modal.bug-report.step.minecraft.messages.minecraft-name=> Minecraft Name: `{0}`
-modal.bug-report.step.report.label=Welchen Bug mÃ¶chtest du melden?
-modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie mÃ¶glich.
+modal.bug-report.step.report.label=Welchen Bug möchtest du melden?
+modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie möglich.
 modal.bug-report.step.report.message.title=# Bug Report
 # Minecraft Support
 modal.minecraft-support.minecraft-name.label=Minecraft Name
@@ -174,116 +174,116 @@ modal.minecraft-support.minecraft-name.placeholder=Dein Minecraft Name
 modal.minecraft-support.minecraft-name.message=> Minecraft Name: `{0}`
 # Common support
 modal.support.step.input.label=Dein Anliegen
-modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie mÃ¶glich.
+modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie möglich.
 modal.support.step.input.message=# Anliegen
 # Survival support
 modal.support.survival.titel=Survival Support
-modal.support.survival.description=Anliegen bezÃ¼glich des Survival Servers
-modal.support.survival.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
+modal.support.survival.description=Anliegen bezüglich des Survival Servers
+modal.support.survival.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
 # Event support
 modal.support.event.titel=Event Support
-modal.support.event.description=Anliegen bezÃ¼glich des Event Servers
-modal.support.event.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
+modal.support.event.description=Anliegen bezüglich des Event Servers
+modal.support.event.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
 # Discord support
 modal.support.discord.titel=Discord Support
-modal.support.discord.description=Anliegen bezÃ¼glich des Discord Servers
-modal.support.discord.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
+modal.support.discord.description=Anliegen bezüglich des Discord Servers
+modal.support.discord.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
 ### Errors
 error.generic=Ein Fehler ist aufgetreten.
 error.no-guild=Du musst dich auf einem Server befinden!
 error.server-not-registered=Dieser Server ist nicht registriert!
-error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszufÃ¼hren!
-error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszufÃ¼hren.
+error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszuführen!
+error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszuführen.
 error.command.arg.missing.user=Du musst einen Benutzer angeben.
 error.command.arg.missing.role=Du musst eine Rolle angeben.
 error.command.arg.missing.number=Du musst eine Zahl angeben.
 error.command.arg.missing.boolean=Du musst einen Wahrheitswert angeben.
 error.command.arg.missing.string=Du musst einen Text angeben.
 error.command.arg.missing.attachment=Du musst eine Anlage angeben.
-error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszufÃ¼hren!
-error.ticket.close=Es ist ein Fehler beim SchlieÃŸen des Tickets aufgetreten.
+error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszuführen!
+error.ticket.close=Es ist ein Fehler beim Schließen des Tickets aufgetreten.
 error.ticket.close.not-found=Das Ticket konnte nicht gefunden werden.
 error.ticket.close.not-closable=Der Ticket-Channel kann nicht geschlossen werden.
 error.ticket.close.already-closing=Das Ticket wird bereits geschlossen.
 error.ticket.close.already-closed=Das Ticket ist bereits geschlossen.
-error.ticket.bot.add=Du kannst den Bot nicht hinzufÃ¼gen.
+error.ticket.bot.add=Du kannst den Bot nicht hinzufügen.
 error.ticket.bot.remove=Du kannst den Bot nicht entfernen.
 error.ticket.member.already-in-ticket=Dieser Nutzer ist bereits in diesem Ticket.
 error.ticket.member.not-in-ticket=Dieser Nutzer ist nicht in diesem Ticket.
-error.ticket.add.member=Der Nutzer konnte nicht hinzugefÃ¼gt werden.
+error.ticket.add.member=Der Nutzer konnte nicht hinzugefügt werden.
 error.ticket.remove.member=Der Nutzer konnte nicht entfernt werden.
 error.minecraft.not-found=Der Spieler konnte nicht gefunden werden.
 error.ticket.whitelist=Es ist ein Fehler aufgetreten. Die Whitelist konnte nicht erstellt werden.
 error.ticket.wlquery.no-user=Es wurde kein Benutzer angegeben.
-error.whitelist.query.no-results=Es wurden keine Whitelist EintrÃ¤ge fÃ¼r `{0}` gefunden.
+error.whitelist.query.no-results=Es wurden keine Whitelist Einträge für `{0}` gefunden.
 error.whitelist.role-not-registered=Die Whitelist Rolle ist nicht registriert.
 error.whitelist.change.not-whitelisted=Der Spieler ist nicht auf der Whitelist.
-error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geÃ¶ffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
-error.ticket.permission.open=Du hast nicht die benÃ¶tigten Berechtigungen, um ein Ticket zu erstellen!
+error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geöffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
+error.ticket.permission.open=Du hast nicht die benötigten Berechtigungen, um ein Ticket zu erstellen!
 error.ticket.whitelist.not-whitelisted=Du musst auf der Whitelist sein, um dieses Ticket zu erstellen.
 error.ticket.whitelist.already-whitelisted=Du bist bereits auf der Whitelist und kannst dieses Ticket nicht erstellen.
-error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknÃ¼pfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
-error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht Ã¶ffentlich. Bitte stelle sicher, dass dein Profil Ã¶ffentlich ist, damit wir deine VerknÃ¼pfung Ã¼berprÃ¼fen kÃ¶nnen.
+error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknüpfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
+error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht öffentlich. Bitte stelle sicher, dass dein Profil öffentlich ist, damit wir deine Verknüpfung überprüfen können.
 ## Misc
-# DonÂ´t ask to ask
+# Don´t ask to ask
 command.dontasktoask.message.title=Frag einfach direkt.
 command.dontasktoask.message.content=Wenn du eine Frage hast, stell sie einfach. Suche nicht nach \
   bestimmten Personen oder Experten. Frage nicht, ob du eine Frage stellen darfst oder ob jemand \
-  wach oder verfÃ¼gbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
+  wach oder verfügbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
 # How to join
 command.howtojoin.arg.user.description=Der Benutzer, der die Anleitung erhalten soll.
 command.howtojoin.message.title=Wie kannst du den CastCrafter-Server betreten?
-command.howtojoin.message.content=MÃ¶chtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
+command.howtojoin.message.content=Möchtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
   - Schau dir unsere Anleitung hier an: [Anleitung zum Beitreten](https://server.castcrafter.de/how-to-join)\n\
-  - Du brauchst keine Whitelist fÃ¼r den Event-Server.\n\
-  - FÃ¼r den Survival-Server brauchst du eine Whitelist.\n\n\
+  - Du brauchst keine Whitelist für den Event-Server.\n\
+  - Für den Survival-Server brauchst du eine Whitelist.\n\n\
    -# Wir freuen uns, dich bald auf dem Server zu sehen!
 # FAQ
 command.faq.arg.question=Die Frage, die beantwortet werden soll.
 command.faq.arg.user=Der Benutzer, der die Antwort erhalten soll.
-command.faq.questions.connect-twitch-with-discord=Wie verknÃ¼pfe ich meinen Twitch Account mit Discord?
-command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknÃ¼pfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
+command.faq.questions.connect-twitch-with-discord=Wie verknüpfe ich meinen Twitch Account mit Discord?
+command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknüpfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
 command.faq.questions.banned=Ich wurde gebannt. Was kann ich tun?
 command.faq.questions.banned.answer=Wenn du denkst, dir ist mit einem Ausschluss vom Server unrecht getan, erstelle einen [Entbannungsantrag](https://server.castcrafter.de/support#unban-ticket)!
-command.faq.questions.event=Wann findet das nÃ¤chste Event statt?
-command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekÃ¼ndigt.
+command.faq.questions.event=Wann findet das nächste Event statt?
+command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekündigt.
 command.faq.questions.open-ticket=Wie erstelle ich ein Ticket?
 command.faq.questions.open-ticket.answer=Eine Anleitung, wie du ein Ticket erstellen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/support.html)
 command.faq.questions.rulebook=Regelwerk
 command.faq.questions.rulebook.answer=Alle Regeln, die auf dem Server gelten, findest du hier: \
   [Regelwerk](https://server.castcrafter.de/rules)\n\n\
-  Bitte lies die Regeln sorgfÃ¤ltig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
-  -# Bei Events **kÃ¶nnen** die Regeln abweichen. \
-  Diese Ã„nderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
+  Bitte lies die Regeln sorgfältig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
+  -# Bei Events **können** die Regeln abweichen. \
+  Diese Änderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
 command.faq.questions.server-modpack=Offizielles Server Modpack
 command.faq.questions.server-modpack.answer=Um das Spielerlebnis auf dem Server zu optimieren \
-  gibt es ein offizielles Modpack, welches ausschlieÃŸlich getestete Modifikationen enthÃ¤lt. \
+  gibt es ein offizielles Modpack, welches ausschließlich getestete Modifikationen enthält. \
   Alle enthaltenen Mods sind erlaubt und mit dem Server kompatibel.\n\
-  **Das Modpack kÃ¶nnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
-  -# **Ã„nderungen am Modpack oder das HinzufÃ¼gen zusÃ¤tzlicher Mods kÃ¶nnen zu InkompatibilitÃ¤ten und \
-  unter UmstÃ¤nden zu einem Ausschluss des Servers fÃ¼hren. \
-  Wir Ã¼bernehmen keine Verantwortung fÃ¼r modifizierte Versionen des Modpacks.**
+  **Das Modpack könnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
+  -# **Änderungen am Modpack oder das Hinzufügen zusätzlicher Mods können zu Inkompatibilitäten und \
+  unter Umständen zu einem Ausschluss des Servers führen. \
+  Wir übernehmen keine Verantwortung für modifizierte Versionen des Modpacks.**
 command.faq.questions.problem-ressourcepack=Probleme mit dem Ressourcenpaket
-command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket lÃ¤d nicht richtig oder du \
-  erhÃ¤ltst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
+command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket läd nicht richtig oder du \
+  erhältst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
   Hier findest du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#resourcepack-issues)
 command.faq.questions.problem-connection=Verbindungsprobleme / Netzwerk Lags
 command.faq.questions.problem-connection.answer=Du kannst dich nicht mit dem Server verbinden, \
-  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmÃ¤ÃŸig starke Lags?\n\
+  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmäßig starke Lags?\n\
   Hier findet du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#connection-issues)
 command.faq.questions.read-the-docs=Dokumentation
-command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausfÃ¼hrlichen \
+command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausführlichen \
   Dokumentation beantwortet: [Dokumentation](https://server.castcrafter.de/community-server-landing-page)\n\n\
-  FÃ¼r detaillierte Anleitungen, Tipps und hÃ¤ufig gestellte Fragen besuche den obigen Link.
+  Für detaillierte Anleitungen, Tipps und häufig gestellte Fragen besuche den obigen Link.
 command.faq.questions.maintenance=Wartungsarbeiten
 command.faq.questions.maintenance.answer=Aktuell finden Wartungsarbeiten statt. \
-  Bitte habe ein wenig Geduld. Weitere Informationen findest du unter https://discord.com/channels/133198459531558912/980810495877607524 und \
+  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal und \
   in der [Dokumentation](https://server.castcrafter.de/current-server-issues.html#server-lockdown)
 ### Menus
 ## Tickets menu
-menu.ticket.select.placeholder=Ticket auswÃ¤hlen
+menu.ticket.select.placeholder=Ticket auswählen
 ### Other
 # Whitelist
 whitelist.query.embed.title=Whitelist Query
@@ -292,12 +292,12 @@ whitelist.query.embed.description=Whitelist Informationen
 whitelist.query.embed.field.minecraft-name=Minecraft Name
 whitelist.query.embed.field.twitch-name=Twitch Link
 whitelist.query.embed.field.discord-user=Discord User
-whitelist.query.embed.field.added-by=HinzugefÃ¼gt von
+whitelist.query.embed.field.added-by=Hinzugefügt von
 whitelist.query.embed.field.uuid=UUID
 whitelist.query.embed.field.blocked=Blockiert
-whitelist.query.start=WlQuery fÃ¼r: `{0}`
+whitelist.query.start=WlQuery für: `{0}`
 # Tickets
-ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von InaktivitÃ¤t automatisch geschlossen.
+ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von Inaktivität automatisch geschlossen.
 # Common
 common.yes=Ja
 common.no=Nein

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,68 +1,68 @@
 ### Interactions
 ## Show Admin Panel
 interaction.context.menu.admin-panel.button=Open Admin Panel
-interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für den Benutzer {0} zu öffnen.
-interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-Einträge für diesen Benutzer gefunden. Daher können wir den Link zum Admin-Panel nicht öffnen.
+interaction.context.menu.admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r den Benutzer {0} zu Ã¶ffnen.
+interaction.context.menu.admin-panel.no-whitelist-entry=Es wurden keine Whitelist-EintrÃ¤ge fÃ¼r diesen Benutzer gefunden. Daher kÃ¶nnen wir den Link zum Admin-Panel nicht Ã¶ffnen.
 interaction.context.menu.admin-panel.no-private-message-allowed=Du hast private Nachrichten deaktiviert oder der Bot darf dir keine Nachrichten senden.
 interaction.context.menu.ticket-admin-panel.not-a-thread=Dieser Befehl kann nur in einem Thread-Kanal verwendet werden.
 interaction.context.menu.ticket-admin-panel.not-a-ticket=Dieser Befehl kann nur in einem Ticket-Thread verwendet werden.
-interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel für das Ticket {0} zu öffnen.
+interaction.context.menu.ticket-admin-panel.private-message=Klicke auf den Button, um das Admin-Panel fÃ¼r das Ticket {0} zu Ã¶ffnen.
 ## Open Ticket
-interaction.button.open-ticket.title=Ticket Typ auswählen
-interaction.button.open-ticket.description=Bitte wähle das passende Ticket aus, welches du öffnen möchtest.\n\
+interaction.button.open-ticket.title=Ticket Typ auswÃ¤hlen
+interaction.button.open-ticket.description=Bitte wÃ¤hle das passende Ticket aus, welches du Ã¶ffnen mÃ¶chtest.\n\
 \n\
 Informationen zu den unterschiedlichen Tickettypen findest du auf https://server.castcrafter.de/support
 ### Commands
 # Request Rollback
-interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurückgesetzt werden sollen.
-interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurückgesetzt werden sollen.
+interaction.command.rollback.arg.player_name=Der Name des Spielers, dessen Daten zurÃ¼ckgesetzt werden sollen.
+interaction.command.rollback.arg.servers=Die Server, auf denen die Daten zurÃ¼ckgesetzt werden sollen.
 interaction.command.rollback.sub.full.description=Markiert den Rollback als einen kompletten Rollback.
-interaction.command.rollback.sub.full.arg.reason=Der Grund für den kompletten Rollback.
+interaction.command.rollback.sub.full.arg.reason=Der Grund fÃ¼r den kompletten Rollback.
 interaction.command.rollback.sub.timed.description=Markiert den Rollback als einen zeitlich begrenzten Rollback.
-interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurückgesetzt werden soll.
+interaction.command.rollback.sub.timed.arg.timerange=Der Zeitraum, der zurÃ¼ckgesetzt werden soll.
 ## Tickets
 ticket.open.success=Dein "{0}"-Ticket wurde erfolgreich erstellt!
 # Ticket Button
 interaction.command.ticket.ticket-button.title=Ticket erstellen
-interaction.command.ticket.ticket-button.description=Du möchtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag für den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
+interaction.command.ticket.ticket-button.description=Du mÃ¶chtest eine Whitelist-Anfrage stellen, einen Spieler bzw. ein Problem melden oder einen Entbannungsantrag fÃ¼r den Server erstellen, so kannst du hier ein Ticket erstellen.\n\
 \n\
 Bitte mache dich **vorher** mit unterschiedlichen Tickettypen vertraut!\n\
-Die Übersicht findest du hier: https://server.castcrafter.de/support\n\
+Die Ãœbersicht findest du hier: https://server.castcrafter.de/support\n\
 \n\
-Allgemeine Fragen sollten in den dafür vorgesehenen öffentlichen Kanälen gestellt werden.\n\
+Allgemeine Fragen sollten in den dafÃ¼r vorgesehenen Ã¶ffentlichen KanÃ¤len gestellt werden.\n\
 \n\
-Wir bemühen uns die Tickets schnellstmöglich zu bearbeiten.\
-  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets länger dauern kann.
+Wir bemÃ¼hen uns die Tickets schnellstmÃ¶glich zu bearbeiten.\
+  Bedenkt jedoch, dass das gesamte Team freiwillig arbeitet und gerade unter der Woche die Bearbeitung der Tickets lÃ¤nger dauern kann.
 # Ticket Close
-interaction.command.ticket.close.arg.reason=Der Grund für das Schließen des Tickets
-interaction.command.ticket.close.closing=Schließe Ticket...
+interaction.command.ticket.close.arg.reason=Der Grund fÃ¼r das SchlieÃŸen des Tickets
+interaction.command.ticket.close.closing=SchlieÃŸe Ticket...
 # Ticket Dependencies not met
-interaction.command.ticket.dependencies-not-met.close-reason=Du erfüllst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket eröffnest.
+interaction.command.ticket.dependencies-not-met.close-reason=Du erfÃ¼llst nicht die [Voraussetzungen](https://server.castcrafter.de/how-to-join#survival-dependencies). Bitte lies dir diese genauer durch, bevor du ein neues Ticket erÃ¶ffnest.
 # Ticket member add
-interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefügt werden soll
-interaction.command.ticket.member.add.adding=Hinzufügen...
-interaction.command.ticket.member.add.checking-bot=Überprüfe, ob der Bot hinzugefügt werden soll...
-interaction.command.ticket.member.add.checking-already-in-ticket=Überprüfe, ob der Nutzer bereits im Ticket ist...
-interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefügt.
+interaction.command.ticket.member.add.arg.member=Der Benutzer, der hinzugefÃ¼gt werden soll
+interaction.command.ticket.member.add.adding=HinzufÃ¼gen...
+interaction.command.ticket.member.add.checking-bot=ÃœberprÃ¼fe, ob der Bot hinzugefÃ¼gt werden soll...
+interaction.command.ticket.member.add.checking-already-in-ticket=ÃœberprÃ¼fe, ob der Nutzer bereits im Ticket ist...
+interaction.command.ticket.member.add.added=Der Nutzer wurde erfolgreich hinzugefÃ¼gt.
 interaction.command.ticket.member.embed.title=Willkommen im Ticket!
-interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefügt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
-interaction.command.ticket.member.embed.footer=Hinzugefügt von {0}
+interaction.command.ticket.member.embed.description=Du wurdest zu einem Ticket hinzugefÃ¼gt. Bitte sieh dir den Verlauf des Tickets an und warte auf eine Nachricht eines Teammitglieds.
+interaction.command.ticket.member.embed.footer=HinzugefÃ¼gt von {0}
 # Ticket member remove
 interaction.command.ticket.member.remove.arg.member=Der Benutzer, der entfernt werden soll
 interaction.command.ticket.member.remove.removing=Entferne...
 interaction.command.ticket.member.remove.removed=Der Nutzer wurde erfolgreich entfernt.
-interaction.command.ticket.member.remove.checking-bot=Überprüfe, ob der Bot entfernt werden soll...
-interaction.command.ticket.member.remove.checking-in-ticket=Überprüfe, ob der Nutzer im Ticket ist...
+interaction.command.ticket.member.remove.checking-bot=ÃœberprÃ¼fe, ob der Bot entfernt werden soll...
+interaction.command.ticket.member.remove.checking-in-ticket=ÃœberprÃ¼fe, ob der Nutzer im Ticket ist...
 interaction.command.ticket.member.remove.announcement={0} wurde von {1} aus dem Ticket entfernt.
 interaction.command.ticket.member.remove.error=Der Nutzer konnte nicht entfernt werden.
 # Whitelist
-interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefügt werden soll.
+interaction.command.ticket.whitelist.arg.user=Der Spieler, der zur Whitelist hinzugefÃ¼gt werden soll.
 interaction.command.ticket.whitelist.arg.minecraft-name=Der Minecraft-Name des Spielers
 interaction.command.ticket.whitelist.arg.twitch-name=Der Twitch-Name des Spielers
 interaction.command.ticket.whitelist.uuid-fetching=UUID wird abgerufen...
-interaction.command.ticket.whitelist.checking=Überprüfe auf vorhandene Whitelists...
-interaction.command.ticket.whitelist.adding=Füge zur Whitelist hinzu...
-interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefügt...
+interaction.command.ticket.whitelist.checking=ÃœberprÃ¼fe auf vorhandene Whitelists...
+interaction.command.ticket.whitelist.adding=FÃ¼ge zur Whitelist hinzu...
+interaction.command.ticket.whitelist.adding-role=Whitelist Rolle wird hinzugefÃ¼gt...
 interaction.command.ticket.whitelist.already-whitelisted=Der Spieler befindet sich bereits auf der Whitelist.
 interaction.command.ticket.whitelist.added={0} befindet sich nun auf der Whitelist.
 interaction.command.ticket.wlquery.querying=Frage Whitelist Informationen ab...
@@ -85,10 +85,10 @@ interaction.command.ticket.whitelist.role.remove.failed={0} Benutzer konnten nic
 # Missing information
 interaction.command.ticket.missing-information.arg.user=Der Benutzer, der die Nachricht erhalten soll.
 interaction.command.ticket.missing-information.message.title=Fehlende Informationen
-interaction.command.ticket.missing-information.message.content=Vielen Dank für deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu können.\n\
+interaction.command.ticket.missing-information.message.content=Vielen Dank fÃ¼r deine Anfrage! Leider fehlen uns noch einige wichtige Informationen, um dir weiterhelfen zu kÃ¶nnen.\n\
   Bitte stelle sicher, dass du die folgenden Punkte bereitstellst:\n\n\
   - **Genaue Koordinaten**, z. B. `110 64 60` (Standort eines Containers)\n\
-  - **Dimension**, z. B. *Nether*\n\
+  - **Dimension**, z.Â B. *Nether*\n\
   - **Beschreibung** des Problems\n\
   - **Server**, auf dem der Fehler aufgetreten ist
 # Whitelist
@@ -97,46 +97,46 @@ modal.whitelist.step.twitch.question.yes=Ja, ich habe meinen Twitch-Account verb
 modal.whitelist.step.twitch.question.no=Nein, ich habe meinen Twitch-Account nicht verbunden oder folge CastCrafter nicht auf Twitch.
 modal.whitelist.step.twitch.error.not-connected=Du hast deinen Twitch-Account nicht mit Discord verbunden.
 modal.whitelist.step.minecraft.label=Minecraft Name
-modal.whitelist.step.minecraft.invalid=Du musst einen gültigen Minecraft-Java Namen angeben.
+modal.whitelist.step.minecraft.invalid=Du musst einen gÃ¼ltigen Minecraft-Java Namen angeben.
 modal.whitelist.step.minecraft.already-whitelisted=Du bist bereits auf der Whitelist.
 modal.whitelist.step.minecraft.open=> Minecraft Name: ```{0}```\n\n\
-Vielen Dank für deine Whitelist Anfrage. \
-Du wirst nun auf die Whitelist hinzugefügt, sobald jemand aus dem Team Zeit findet. \
+Vielen Dank fÃ¼r deine Whitelist Anfrage. \
+Du wirst nun auf die Whitelist hinzugefÃ¼gt, sobald jemand aus dem Team Zeit findet. \
 Wir bitten um etwas Geduld.
 modal.whitelist.title=Whitelist Ticket
-modal.whitelist.description=Whitelist Anfrage für den Survival Server
+modal.whitelist.description=Whitelist Anfrage fÃ¼r den Survival Server
 # Report
 modal.report.step.selection.griefing.title=Auf welchem Server wurdest du gegrieft?
 modal.report.step.selection.griefing.survival1.label=Survival 01
 modal.report.step.selection.griefing.survival2.label=Survival 02
-modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wähle diese Option!
+modal.report.step.selection.griefing.survival.description=Du wurdest auf dem Survival Server gegrieft? Dann wÃ¤hle diese Option!
 modal.report.step.selection.griefing.event.label=Event
-modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wähle diese Option!
+modal.report.step.selection.griefing.event.description=Du wurdest auf dem Event Server gegrieft? Dann wÃ¤hle diese Option!
 modal.report.step.griefing.input.world.label=Welt
 modal.report.step.griefing.input.world.placeholder=overworld
 modal.report.step.griefing.input.xyz.label=X Y Z
 modal.report.step.griefing.input.xyz.placeholder=123 64 321
 modal.report.step.griefing.input.what-griefed.label=Was wurde gegrieft?
-modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschädigten Strukturen oder gestohlenen Gegenstände.
-modal.report.step.griefing.input.additional-info.label=Zusätzliche Informationen
-modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen möchtest?
+modal.report.step.griefing.input.what-griefed.placeholder=Beschreibe die beschÃ¤digten Strukturen oder gestohlenen GegenstÃ¤nde.
+modal.report.step.griefing.input.additional-info.label=ZusÃ¤tzliche Informationen
+modal.report.step.griefing.input.additional-info.placeholder=Gibt es noch etwas, das du uns mitteilen mÃ¶chtest?
 modal.report.step.griefing.messages.server=> Server: `{0}`
 modal.report.step.griefing.messages.location=> Location: `{0}` - `{1}`
 modal.report.step.player.input.reporting-player.label=Dein Spielname
 modal.report.step.player.input.reason.label=Grund
 modal.report.step.player.input.reason.placeholder=Was hat der Spielende getan?
 modal.report.step.player.messages.reporting-player=> Meldender Spielende: `{0}`
-modal.report.step.type.selection.title=Möchtest du Griefing oder einen Spieler Melden?
+modal.report.step.type.selection.title=MÃ¶chtest du Griefing oder einen Spieler Melden?
 modal.report.step.type.selection.griefing.label=Griefing
-modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wähle diese Option!
+modal.report.step.type.selection.griefing.description=Du wurdest gegrieft? Dann wÃ¤hle diese Option!
 modal.report.step.type.selection.player.label=Spieler
-modal.report.step.type.selection.player.description=Du möchtest einen Spieler melden? Dann wähle diese Option!
+modal.report.step.type.selection.player.description=Du mÃ¶chtest einen Spieler melden? Dann wÃ¤hle diese Option!
 modal.report.step.type.input.griefing.own-name=Dein Spielername
 modal.report.step.type.input.report.reported-player=Zu meldender Spielername
 modal.report.step.type.messages.player-name=> Spielername: `{0}`
 modal.report.title=Report
-modal.report.description=Melde Griefing, Cheating oder andere Regelverstöße.
-modal.report.message=Danke für deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir den Vorfall untersuchen.
+modal.report.description=Melde Griefing, Cheating oder andere RegelverstÃ¶ÃŸe.
+modal.report.message=Danke fÃ¼r deine Meldung! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir den Vorfall untersuchen.
 # Unban
 modal.unban.step.type.selection.title=Wurdest du wegen `Unerlaubte Clientmodifikationen` gebannt?
 modal.unban.step.type.selection.yes.label=Ja
@@ -148,25 +148,25 @@ modal.unban.step.punishment-id.input.placeholder=Deine Punishment ID
 modal.unban.step.punishment-id.messages.punishment-id=> Punishment ID: ``{0}``
 modal.unban.step.punishment-id.error.invalid=Es konnte kein Ausschluss mit der eingegebenen ID gefunden werden!
 modal.unban.step.appeal.input.appeal.label=Dein Entbannungsantrag
-modal.unban.step.appeal.input.appeal.placeholder=Erkläre, warum du entbannt werden möchtest und was du aus deinem Verhalten gelernt hast.
+modal.unban.step.appeal.input.appeal.placeholder=ErklÃ¤re, warum du entbannt werden mÃ¶chtest und was du aus deinem Verhalten gelernt hast.
 modal.unban.step.appeal.messages.appeal.title=# Entbannungsantrag
 modal.unban.step.appeal.messages.appeal=> {0}
 modal.unban.step.modlist.input.label=Modifikationsliste
 modal.unban.step.modlist.input.placeholder=Bitte gebe hier AUSNAHMSLOS ALLE Modifikationen an, die du benutzt hast! (Screenshot / Liste)
 modal.unban.step.modlist.messages.open=> Modifikationsliste: [{0}]
 modal.unban.title=Entbannungsantrag
-modal.unban.description=Entbannungsanträge für den Community Server
-modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von Entbannungsanträgen während laufender Events **bis zu 24 Stunden** dauern kann!
+modal.unban.description=EntbannungsantrÃ¤ge fÃ¼r den Community Server
+modal.unban.message=Wir haben deine Anfrage erhalten. Bitte beachte, dass die Bearbeitung von EntbannungsantrÃ¤gen wÃ¤hrend laufender Events **bis zu 24 Stunden** dauern kann!
 # Bug Report
 modal.bug-report.title=Bug Report
 modal.bug-report.description=Fehler gefunden? Melde ihn hier.
-modal.bug-report.message=Danke für deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kümmern.\
-  \ Bitte hab etwas Geduld, während wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
-  \ die den Fehler zeigen, füge diese bitte hinzu.
+modal.bug-report.message=Danke fÃ¼r deinen Bug Report! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern.\
+  \ Bitte hab etwas Geduld, wÃ¤hrend wir den Fehler untersuchen. \n-# Solltest du weitere Informationen haben, oder Bilder / Videos, \
+  \ die den Fehler zeigen, fÃ¼ge diese bitte hinzu.
 modal.bug-report.step.minecraft.label=Minecraft Name
 modal.bug-report.step.minecraft.messages.minecraft-name=> Minecraft Name: `{0}`
-modal.bug-report.step.report.label=Welchen Bug möchtest du melden?
-modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie möglich.
+modal.bug-report.step.report.label=Welchen Bug mÃ¶chtest du melden?
+modal.bug-report.step.report.placeholder=Beschreibe den Bug so genau wie mÃ¶glich.
 modal.bug-report.step.report.message.title=# Bug Report
 # Minecraft Support
 modal.minecraft-support.minecraft-name.label=Minecraft Name
@@ -174,116 +174,116 @@ modal.minecraft-support.minecraft-name.placeholder=Dein Minecraft Name
 modal.minecraft-support.minecraft-name.message=> Minecraft Name: `{0}`
 # Common support
 modal.support.step.input.label=Dein Anliegen
-modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie möglich.
+modal.support.step.input.placeholder=Beschreibe dein Anliegen so genau wie mÃ¶glich.
 modal.support.step.input.message=# Anliegen
 # Survival support
 modal.support.survival.titel=Survival Support
-modal.support.survival.description=Anliegen bezüglich des Survival Servers
-modal.support.survival.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
+modal.support.survival.description=Anliegen bezÃ¼glich des Survival Servers
+modal.support.survival.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
 # Event support
 modal.support.event.titel=Event Support
-modal.support.event.description=Anliegen bezüglich des Event Servers
-modal.support.event.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
+modal.support.event.description=Anliegen bezÃ¼glich des Event Servers
+modal.support.event.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
 # Discord support
 modal.support.discord.titel=Discord Support
-modal.support.discord.description=Anliegen bezüglich des Discord Servers
-modal.support.discord.message=Danke für deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kümmern. Bitte hab etwas Geduld, während wir dein Anliegen bearbeiten.
+modal.support.discord.description=Anliegen bezÃ¼glich des Discord Servers
+modal.support.discord.message=Danke fÃ¼r deine Anfrage! Wir haben deine Informationen erhalten und werden uns bald darum kÃ¼mmern. Bitte hab etwas Geduld, wÃ¤hrend wir dein Anliegen bearbeiten.
 ### Errors
 error.generic=Ein Fehler ist aufgetreten.
 error.no-guild=Du musst dich auf einem Server befinden!
 error.server-not-registered=Dieser Server ist nicht registriert!
-error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszuführen!
-error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszuführen.
+error.no-thread-channel=Du musst dich in einem Threadkanal befinden, um diesen Befehl auszufÃ¼hren!
+error.command.no-permission=Du hast keine Berechtigung, diesen Befehl auszufÃ¼hren.
 error.command.arg.missing.user=Du musst einen Benutzer angeben.
 error.command.arg.missing.role=Du musst eine Rolle angeben.
 error.command.arg.missing.number=Du musst eine Zahl angeben.
 error.command.arg.missing.boolean=Du musst einen Wahrheitswert angeben.
 error.command.arg.missing.string=Du musst einen Text angeben.
 error.command.arg.missing.attachment=Du musst eine Anlage angeben.
-error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszuführen!
-error.ticket.close=Es ist ein Fehler beim Schließen des Tickets aufgetreten.
+error.ticket.no-ticket-channel=Du musst dich in einem Ticketkanal befinden, um diesen Befehl auszufÃ¼hren!
+error.ticket.close=Es ist ein Fehler beim SchlieÃŸen des Tickets aufgetreten.
 error.ticket.close.not-found=Das Ticket konnte nicht gefunden werden.
 error.ticket.close.not-closable=Der Ticket-Channel kann nicht geschlossen werden.
 error.ticket.close.already-closing=Das Ticket wird bereits geschlossen.
 error.ticket.close.already-closed=Das Ticket ist bereits geschlossen.
-error.ticket.bot.add=Du kannst den Bot nicht hinzufügen.
+error.ticket.bot.add=Du kannst den Bot nicht hinzufÃ¼gen.
 error.ticket.bot.remove=Du kannst den Bot nicht entfernen.
 error.ticket.member.already-in-ticket=Dieser Nutzer ist bereits in diesem Ticket.
 error.ticket.member.not-in-ticket=Dieser Nutzer ist nicht in diesem Ticket.
-error.ticket.add.member=Der Nutzer konnte nicht hinzugefügt werden.
+error.ticket.add.member=Der Nutzer konnte nicht hinzugefÃ¼gt werden.
 error.ticket.remove.member=Der Nutzer konnte nicht entfernt werden.
 error.minecraft.not-found=Der Spieler konnte nicht gefunden werden.
 error.ticket.whitelist=Es ist ein Fehler aufgetreten. Die Whitelist konnte nicht erstellt werden.
 error.ticket.wlquery.no-user=Es wurde kein Benutzer angegeben.
-error.whitelist.query.no-results=Es wurden keine Whitelist Einträge für `{0}` gefunden.
+error.whitelist.query.no-results=Es wurden keine Whitelist EintrÃ¤ge fÃ¼r `{0}` gefunden.
 error.whitelist.role-not-registered=Die Whitelist Rolle ist nicht registriert.
 error.whitelist.change.not-whitelisted=Der Spieler ist nicht auf der Whitelist.
-error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geöffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
-error.ticket.permission.open=Du hast nicht die benötigten Berechtigungen, um ein Ticket zu erstellen!
+error.ticket.type.already-open=Du hast bereits ein Ticket mit dem angegebenen Typ geÃ¶ffnet. Sollte dies nicht der Fall sein, wende dich per Ping an @keviro.
+error.ticket.permission.open=Du hast nicht die benÃ¶tigten Berechtigungen, um ein Ticket zu erstellen!
 error.ticket.whitelist.not-whitelisted=Du musst auf der Whitelist sein, um dieses Ticket zu erstellen.
 error.ticket.whitelist.already-whitelisted=Du bist bereits auf der Whitelist und kannst dieses Ticket nicht erstellen.
-error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknüpfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
-error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht öffentlich. Bitte stelle sicher, dass dein Profil öffentlich ist, damit wir deine Verknüpfung überprüfen können.
+error.ticket.whitelist.twitch-not-connected=Du musst deinen Twitch-Account mit Discord verknÃ¼pfen und CastCrafter auf Twitch folgen, um auf die Whitelist zu kommen.
+error.ticket.whitelist.twitch-not-public=Dein Twitch-Profil ist nicht Ã¶ffentlich. Bitte stelle sicher, dass dein Profil Ã¶ffentlich ist, damit wir deine VerknÃ¼pfung Ã¼berprÃ¼fen kÃ¶nnen.
 ## Misc
-# Don´t ask to ask
+# DonÂ´t ask to ask
 command.dontasktoask.message.title=Frag einfach direkt.
 command.dontasktoask.message.content=Wenn du eine Frage hast, stell sie einfach. Suche nicht nach \
   bestimmten Personen oder Experten. Frage nicht, ob du eine Frage stellen darfst oder ob jemand \
-  wach oder verfügbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
+  wach oder verfÃ¼gbar ist. Stell deine Frage direkt im Kanal und warte geduldig auf eine Antwort.
 # How to join
 command.howtojoin.arg.user.description=Der Benutzer, der die Anleitung erhalten soll.
 command.howtojoin.message.title=Wie kannst du den CastCrafter-Server betreten?
-command.howtojoin.message.content=Möchtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
+command.howtojoin.message.content=MÃ¶chtest du Teil unserer Community werden? Hier ist eine einfache Anleitung, wie du dem Server beitreten kannst:\n\
   - Schau dir unsere Anleitung hier an: [Anleitung zum Beitreten](https://server.castcrafter.de/how-to-join)\n\
-  - Du brauchst keine Whitelist für den Event-Server.\n\
-  - Für den Survival-Server brauchst du eine Whitelist.\n\n\
+  - Du brauchst keine Whitelist fÃ¼r den Event-Server.\n\
+  - FÃ¼r den Survival-Server brauchst du eine Whitelist.\n\n\
    -# Wir freuen uns, dich bald auf dem Server zu sehen!
 # FAQ
 command.faq.arg.question=Die Frage, die beantwortet werden soll.
 command.faq.arg.user=Der Benutzer, der die Antwort erhalten soll.
-command.faq.questions.connect-twitch-with-discord=Wie verknüpfe ich meinen Twitch Account mit Discord?
-command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknüpfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
+command.faq.questions.connect-twitch-with-discord=Wie verknÃ¼pfe ich meinen Twitch Account mit Discord?
+command.faq.questions.connect-twitch-with-discord.answer=Eine Anleitung, wie du deinen Twitch Account mit Discord verknÃ¼pfen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/faq.html#link-twitch)
 command.faq.questions.banned=Ich wurde gebannt. Was kann ich tun?
 command.faq.questions.banned.answer=Wenn du denkst, dir ist mit einem Ausschluss vom Server unrecht getan, erstelle einen [Entbannungsantrag](https://server.castcrafter.de/support#unban-ticket)!
-command.faq.questions.event=Wann findet das nächste Event statt?
-command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekündigt.
+command.faq.questions.event=Wann findet das nÃ¤chste Event statt?
+command.faq.questions.event.answer=Wenn ein Event geplant ist, wird dies im Discord unter https://discord.com/channels/133198459531558912/980810495877607524 oder durch CastCrafter im Stream angekÃ¼ndigt.
 command.faq.questions.open-ticket=Wie erstelle ich ein Ticket?
 command.faq.questions.open-ticket.answer=Eine Anleitung, wie du ein Ticket erstellen kannst, findest du hier: [Anleitung](https://server.castcrafter.de/support.html)
 command.faq.questions.rulebook=Regelwerk
 command.faq.questions.rulebook.answer=Alle Regeln, die auf dem Server gelten, findest du hier: \
   [Regelwerk](https://server.castcrafter.de/rules)\n\n\
-  Bitte lies die Regeln sorgfältig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
-  -# Bei Events **können** die Regeln abweichen. \
-  Diese Änderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
+  Bitte lies die Regeln sorgfÃ¤ltig durch, um sicherzustellen, dass alle Mitglieder eine positive Erfahrung haben.\n\n\
+  -# Bei Events **kÃ¶nnen** die Regeln abweichen. \
+  Diese Ã„nderungen findest du auf der jeweiligen Event-Seite in der Dokumentation.
 command.faq.questions.server-modpack=Offizielles Server Modpack
 command.faq.questions.server-modpack.answer=Um das Spielerlebnis auf dem Server zu optimieren \
-  gibt es ein offizielles Modpack, welches ausschließlich getestete Modifikationen enthält. \
+  gibt es ein offizielles Modpack, welches ausschlieÃŸlich getestete Modifikationen enthÃ¤lt. \
   Alle enthaltenen Mods sind erlaubt und mit dem Server kompatibel.\n\
-  **Das Modpack könnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
-  -# **Änderungen am Modpack oder das Hinzufügen zusätzlicher Mods können zu Inkompatibilitäten und \
-  unter Umständen zu einem Ausschluss des Servers führen. \
-  Wir übernehmen keine Verantwortung für modifizierte Versionen des Modpacks.**
+  **Das Modpack kÃ¶nnt ihr auf [Modrinth](https://modrinth.com/modpack/castcrafter-survival-server) herunterladen.**\n\n\
+  -# **Ã„nderungen am Modpack oder das HinzufÃ¼gen zusÃ¤tzlicher Mods kÃ¶nnen zu InkompatibilitÃ¤ten und \
+  unter UmstÃ¤nden zu einem Ausschluss des Servers fÃ¼hren. \
+  Wir Ã¼bernehmen keine Verantwortung fÃ¼r modifizierte Versionen des Modpacks.**
 command.faq.questions.problem-ressourcepack=Probleme mit dem Ressourcenpaket
-command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket läd nicht richtig oder du \
-  erhältst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
+command.faq.questions.problem-ressourcepack.answer=Das Ressourcenpaket lÃ¤d nicht richtig oder du \
+  erhÃ¤ltst dauerhaft die Nachricht `Aktiviere Ressourcenpaket...`?\n\
   Hier findest du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#resourcepack-issues)
 command.faq.questions.problem-connection=Verbindungsprobleme / Netzwerk Lags
 command.faq.questions.problem-connection.answer=Du kannst dich nicht mit dem Server verbinden, \
-  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmäßig starke Lags?\n\
+  wirst wegen `Unstable Connection` vom Server geworfen oder hast regelmÃ¤ÃŸig starke Lags?\n\
   Hier findet du eine Anleitung, wie du das Problem beheben kannst: \
   [Anleitung](https://server.castcrafter.de/troubleshooting.html#connection-issues)
 command.faq.questions.read-the-docs=Dokumentation
-command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausführlichen \
+command.faq.questions.read-the-docs.answer=Diese und weitere Fragen werden in unserer ausfÃ¼hrlichen \
   Dokumentation beantwortet: [Dokumentation](https://server.castcrafter.de/community-server-landing-page)\n\n\
-  Für detaillierte Anleitungen, Tipps und häufig gestellte Fragen besuche den obigen Link.
+  FÃ¼r detaillierte Anleitungen, Tipps und hÃ¤ufig gestellte Fragen besuche den obigen Link.
 command.faq.questions.maintenance=Wartungsarbeiten
 command.faq.questions.maintenance.answer=Aktuell finden Wartungsarbeiten statt. \
-  Bitte habe ein wenig Geduld. Weitere Informationen findest du im server-updates Kanal und \
+  Bitte habe ein wenig Geduld. Weitere Informationen findest du unter https://discord.com/channels/133198459531558912/980810495877607524 und \
   in der [Dokumentation](https://server.castcrafter.de/current-server-issues.html#server-lockdown)
 ### Menus
 ## Tickets menu
-menu.ticket.select.placeholder=Ticket auswählen
+menu.ticket.select.placeholder=Ticket auswÃ¤hlen
 ### Other
 # Whitelist
 whitelist.query.embed.title=Whitelist Query
@@ -292,12 +292,12 @@ whitelist.query.embed.description=Whitelist Informationen
 whitelist.query.embed.field.minecraft-name=Minecraft Name
 whitelist.query.embed.field.twitch-name=Twitch Link
 whitelist.query.embed.field.discord-user=Discord User
-whitelist.query.embed.field.added-by=Hinzugefügt von
+whitelist.query.embed.field.added-by=HinzugefÃ¼gt von
 whitelist.query.embed.field.uuid=UUID
 whitelist.query.embed.field.blocked=Blockiert
-whitelist.query.start=WlQuery für: `{0}`
+whitelist.query.start=WlQuery fÃ¼r: `{0}`
 # Tickets
-ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von Inaktivität automatisch geschlossen.
+ticket.close.inactive.close-reason=Das Ticket wurde aufgrund von InaktivitÃ¤t automatisch geschlossen.
 # Common
 common.yes=Ja
 common.no=Nein


### PR DESCRIPTION
This pull request adds a new FAQ question about maintenance to the Discord bot's FAQ command and updates the localization file to include the corresponding translations.

### Additions to FAQ functionality:

* [`FAQCommand.kt`](diffhunk://#diff-b4b8b688db88099e17da7912f6f19befb56c87cfbb47c4a211816815eaab6b24R71-R75): Added a new `Question` with the identifier `"maintenance"`, along with its question and answer text, to the FAQ command's list of questions.

### Localization updates:

* [`messages.properties`](diffhunk://#diff-0771b708161a9fbc2a5e9a05637222f39afce6e028cd010abcbaaaee1ade7653R280-R282): Added German translations for the new maintenance FAQ question (`command.faq.questions.maintenance`) and its answer (`command.faq.questions.maintenance.answer`).