### PR TITLE
Feat/update wl query embed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,6 @@
 *.tar.gz
 *.rar
 
-src/main/kotlin/dev/slne/discord/guild/DiscordGuilds.kt
-
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 *.tar.gz
 *.rar
 
+src/main/kotlin/dev/slne/discord/guild/DiscordGuilds.kt
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*

--- a/src/main/kotlin/dev/slne/discord/Bootstrap.kt
+++ b/src/main/kotlin/dev/slne/discord/Bootstrap.kt
@@ -34,6 +34,7 @@ class Bootstrap(
             RawMessages::class.java.getClassLoader()
 
             listenForCommands(jda, commandProcessor)
+            Bootstrap.jda = jda
         }
 
         logger.info("Done and ready ({}ms)! Type 'help' for a list of commands.", ms)
@@ -42,7 +43,13 @@ class Bootstrap(
     @PreDestroy
     fun onDisable() {
     }
+
+    companion object {
+        lateinit var jda: JDA
+    }
 }
+
+val jda get() = Bootstrap.jda
 
 private fun listenForCommands(
     jda: JDA,

--- a/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/whitelist/WhitelistQueryCommand.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/whitelist/WhitelistQueryCommand.kt
@@ -2,17 +2,22 @@ package dev.slne.discord.discord.interaction.command.commands.whitelist
 
 import dev.minn.jda.ktx.coroutines.await
 import dev.minn.jda.ktx.interactions.components.getOption
+import dev.minn.jda.ktx.messages.Embed
 import dev.slne.discord.annotation.DiscordCommandMeta
 import dev.slne.discord.discord.interaction.command.DiscordCommand
 import dev.slne.discord.exception.command.CommandExceptions
 import dev.slne.discord.guild.permission.CommandPermission
+import dev.slne.discord.jda
+import dev.slne.discord.message.EmbedColors.WL_QUERY
 import dev.slne.discord.message.MessageManager
 import dev.slne.discord.message.translatable
+import dev.slne.discord.persistence.external.Whitelist
 import dev.slne.discord.persistence.service.user.UserService
 import dev.slne.discord.persistence.service.whitelist.WhitelistService
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
+import java.time.ZonedDateTime
 
 private const val USER_OPTION: String = "user"
 private const val MINECRAFT_OPTION: String = "minecraft"
@@ -51,7 +56,6 @@ class WhitelistQueryCommand(
         interaction: SlashCommandInteractionEvent,
         hook: InteractionHook
     ) {
-        val channel = interaction.channel
         val user = interaction.getOption<User>(USER_OPTION)
         val minecraft = interaction.getOption<String>(MINECRAFT_OPTION)
         val twitch = interaction.getOption<String>(TWITCH_OPTION)
@@ -61,36 +65,12 @@ class WhitelistQueryCommand(
         }
 
         hook.editOriginal(translatable("interaction.command.ticket.wlquery.querying")).await()
-        val whitelists = getWhitelists(user, minecraft, twitch)
-
-        if (user != null) {
-            messageManager.printUserWlQuery(
-                whitelists,
-                user.name,
-                channel,
-                hook,
-                interaction,
+        hook.editOriginalEmbeds(getWhitelists(user, minecraft, twitch).map {
+            getEmbed(
+                it,
                 interaction.user.name
             )
-        } else if (minecraft != null) {
-            messageManager.printUserWlQuery(
-                whitelists,
-                minecraft,
-                channel,
-                hook,
-                interaction,
-                interaction.user.name
-            )
-        } else if (twitch != null) {
-            messageManager.printUserWlQuery(
-                whitelists,
-                twitch,
-                channel,
-                hook,
-                interaction,
-                interaction.user.name
-            )
-        }
+        }).await()
     }
 
     private suspend fun getWhitelists(
@@ -107,5 +87,63 @@ class WhitelistQueryCommand(
         } ?: emptyList()
     } else {
         throw CommandExceptions.TICKET_WLQUERY_NO_USER.create()
+    }
+
+    suspend fun getEmbed(whitelist: Whitelist, requester: String?) = Embed {
+        title = translatable("whitelist.query.embed.title")
+        footer {
+            name = if (requester != null) {
+                translatable("whitelist.query.embed.footer", requester)
+            } else {
+                translatable("whitelist.query.embed.footer.no-requester")
+            }
+            iconUrl = jda.selfUser.avatarUrl
+        }
+        description = null
+        color = WL_QUERY
+        timestamp = ZonedDateTime.now()
+
+        val minecraftName = userService.getUsernameByUuid(whitelist.uuid)
+        val twitchLink = whitelist.twitchLink
+        val uuid = whitelist.uuid
+        val discordUser = whitelist.user?.await()
+        val addedBy = whitelist.addedBy?.await()
+
+        field {
+            name = translatable("whitelist.query.embed.field.uuid")
+            value = uuid.toString()
+            inline = false
+        }
+
+        if (minecraftName != null) {
+            field {
+                name = translatable("whitelist.query.embed.field.minecraft-name")
+                value = "`${minecraftName}`"
+            }
+        }
+
+        field {
+            name = translatable("whitelist.query.embed.field.twitch-name")
+            value = "[${twitchLink}](${whitelist.clickableTwitchLink})"
+        }
+
+        if (discordUser != null) {
+            field {
+                name = translatable("whitelist.query.embed.field.discord-user")
+                value = discordUser.asMention
+            }
+        }
+
+        if (addedBy != null) {
+            field {
+                name = translatable("whitelist.query.embed.field.added-by")
+                value = addedBy.asMention
+            }
+        }
+
+        field {
+            name = translatable("whitelist.query.embed.field.blocked")
+            value = if (whitelist.blocked) translatable("common.yes") else translatable("common.no")
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,4 @@ logging.logback.rollingpolicy.max-history=30
 logging.logback.rollingpolicy.total-size-cap=1GB
 logging.include-application-name=false
 logging.level.*=debug
+


### PR DESCRIPTION
This pull request refactors the whitelist query command to improve how whitelist information is displayed to users. The main change is the introduction of a new embed-based response, replacing the previous message-based approach. Additionally, the JDA instance is now globally accessible, which supports the new embed functionality.

**Whitelist query command improvements:**

* Replaced the previous message-based whitelist query response with a new embed-based response by introducing a `getEmbed` function that formats whitelist information in a Discord embed, including details such as Minecraft name, Twitch link, Discord user, who added the entry, and blocked status. [[1]](diffhunk://#diff-4f6be680af81b0a1e5922eed668dc307418f94e61c96696a87958db1a5672120L64-R73) [[2]](diffhunk://#diff-4f6be680af81b0a1e5922eed668dc307418f94e61c96696a87958db1a5672120R91-R148)
* Updated imports and logic in `WhitelistQueryCommand.kt` to support embed creation and use the globally accessible JDA instance.

**JDA instance accessibility:**

* Made the `JDA` instance globally accessible by adding a static reference in the `Bootstrap` class and a top-level `jda` getter. This allows other parts of the codebase to access the bot's user information for embed footers and other features. [[1]](diffhunk://#diff-99b7cb176bcf998eff95c1d411ecd77ac9a29985a0df64e0c1966bc1c1db379dR37) [[2]](diffhunk://#diff-99b7cb176bcf998eff95c1d411ecd77ac9a29985a0df64e0c1966bc1c1db379dR46-R53)

**Minor changes:**

* Added a blank line to `application.properties` (no functional impact).