### PR TITLE
feat: add support for additional ticket view permissions in DiscordRolePermissions

### DIFF
--- a/src/main/kotlin/dev/slne/discord/guild/DiscordGuilds.kt
+++ b/src/main/kotlin/dev/slne/discord/guild/DiscordGuilds.kt
@@ -80,7 +80,10 @@ enum class DiscordGuilds(val discordGuild: DiscordGuild) {
                 DiscordRolePermissions(
                     discordRoleIds = listOf("1242929429747994664"),
                     ticketViewPermissions = listOf(
-                        TicketViewPermission.VIEW_BUGREPORT_TICKETS
+                        TicketViewPermission.VIEW_BUGREPORT_TICKETS,
+                        TicketViewPermission.VIEW_EVENT_SUPPORT_TICKETS,
+                        TicketViewPermission.VIEW_SURVIVAL_SUPPORT_TICKETS,
+                        TicketViewPermission.VIEW_WHITELIST_TICKETS
                     ),
                     commandPermissions = listOf(
                         CommandPermission.NO_INTEREST,


### PR DESCRIPTION
This pull request expands the ticket view permissions for a specific Discord role in the `DiscordGuilds` enum. The role now has access to additional types of support tickets, improving their ability to assist users across more ticket categories.

**Permission updates:**

* Expanded the `ticketViewPermissions` list for a Discord role to include `VIEW_EVENT_SUPPORT_TICKETS`, `VIEW_SURVIVAL_SUPPORT_TICKETS`, and `VIEW_WHITELIST_TICKETS`, in addition to the existing `VIEW_BUGREPORT_TICKETS`.