### PR TITLE
feat: add survival downtime FAQ question and answer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.2.4-SNAPSHOT
+version=5.2.5-SNAPSHOT

--- a/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/FAQCommand.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/command/commands/misc/FAQCommand.kt
@@ -88,6 +88,11 @@ class FAQCommand : DiscordCommand() {
             "take-part-in-event",
             translatable("command.faq.questions.take-part-in-event"),
             translatable("command.faq.questions.take-part-in-event.answer")
+        ),
+        Question(
+            "survival-downtime",
+            translatable("command.faq.questions.survival-downtime"),
+            translatable("command.faq.questions.survival-downtime.answer")
         )
     ).associateBy { it.identifier }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -315,6 +315,10 @@ command.faq.questions.clan-info.answer=Du suchst den Besitzer eines Clans oder m
   [Hier](https://server.castcrafter.de/clan-more-info.html) findest du eine Übersicht mit zusätzlichen Informationen.
 command.faq.questions.take-part-in-event=Wie kann ich an einem Event teilnehmen?
 command.faq.questions.take-part-in-event.answer=[Hier](https://server.castcrafter.de/how-to-take-part-in-an-event.html) findest du eine Anleitung zur Teilnahme an einem Event.
+command.faq.questions.survival-downtime=Warum ist der Survival Server nicht erreichbar?
+command.faq.questions.survival-downtime.answer=Der 1.21 Survival Server ist zu Ende! \
+  Wann der neue Survival Server startet, steht noch in den Sternen - aber wir arbeiten daran! \
+  Updates & Ankündigungen findest du in https://discord.com/channels/133198459531558912/980810495877607524
 ### Menus
 ## Tickets menu
 menu.ticket.select.placeholder=Ticket auswählen
@@ -338,4 +342,3 @@ common.yes=Ja
 common.no=Nein
 common.waiting.for.ping=Warte auf Pings...
 interaction.context.menu.ticket-admin-panel.not-a-member={0} ist nicht in diesem Thread!
-


### PR DESCRIPTION
This pull request adds a new FAQ entry to explain the downtime of the Survival server. The main changes include updating both the command logic and the user-facing messages to include this new question and answer.

**FAQ update:**

* Added a new `Question` for "survival-downtime" to the list of FAQ questions in `FAQCommand.kt`, allowing users to ask why the Survival server is unavailable.
* Added corresponding entries for the question and answer about Survival server downtime in `messages.properties`, including a link to the Discord channel for updates.

There are no other significant changes in this pull request.