### PR TITLE
feat: filter out WHITELIST and SURVIVAL_SUPPORT ticket types from sel…

### DIFF
--- a/src/main/kotlin/dev/slne/discord/discord/interaction/select/menus/TicketsMenu.kt
+++ b/src/main/kotlin/dev/slne/discord/discord/interaction/select/menus/TicketsMenu.kt
@@ -17,14 +17,15 @@ class TicketsMenu(
 ) : DiscordSelectMenu(
     "menu:tickets-$idSuffix",
     translatable("menu.ticket.select.placeholder"),
-    TicketType.entries.map { ticketType ->
-        SelectOption(
-            ticketType.displayName,
-            ticketType.configName,
-            ticketType.description.run { substring(0, min(length, 100)) },
-            ticketType.emoji
-        )
-    },
+    TicketType.entries.filter { it != TicketType.WHITELIST && it != TicketType.SURVIVAL_SUPPORT }
+        .map { ticketType ->
+            SelectOption(
+                ticketType.displayName,
+                ticketType.configName,
+                ticketType.description.run { substring(0, min(length, 100)) },
+                ticketType.emoji
+            )
+        },
     1..1
 ) {
     override suspend fun onSelect(


### PR DESCRIPTION
…ection menu

This pull request makes a targeted update to the `TicketsMenu` in order to refine the ticket selection options presented to users. Specifically, it filters out certain ticket types from the menu.

Menu option filtering:

* [`src/main/kotlin/dev/slne/discord/discord/interaction/select/menus/TicketsMenu.kt`](diffhunk://#diff-822157463b5f5ec210d812234f478eadb0f6070d20bb7736419c36c2d35a22d1L20-R21): Updated the construction of the select menu to exclude `TicketType.WHITELIST` and `TicketType.SURVIVAL_SUPPORT` from the list of selectable ticket types, ensuring these options are no longer presented to users.