### PR TITLE
chore: bump version to 5.2.8-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.2.7-SNAPSHOT
+version=5.2.8-SNAPSHOT


### PR DESCRIPTION
This pull request makes a small change to the project version in `gradle.properties`, updating it from `5.2.7-SNAPSHOT` to `5.2.8-SNAPSHOT`.