### PR TITLE
fix: add downtime message for survival server in ticket creation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.3.1-SNAPSHOT
+version=5.3.2-SNAPSHOT

--- a/src/main/kotlin/dev/slne/discord/message/MessageManager.kt
+++ b/src/main/kotlin/dev/slne/discord/message/MessageManager.kt
@@ -213,4 +213,13 @@ class MessageManager(
             }
         }
     }
+
+    fun buildSurvivalServerDowntimeEmbed() = MessageCreate {
+        embed {
+            title = translatable("command.faq.questions.survival-downtime")
+            description = translatable("command.faq.questions.survival-downtime.answer")
+            timestamp = ZonedDateTime.now()
+            color = EmbedColors.FAQ
+        }
+    }
 }


### PR DESCRIPTION
This is a mess https://github.com/SLNE-Development/surf-discord/commit/fef577991afb3b4d62c49a76954fec198748e27a

User now gets informed about what is going on instead of just hiding the categories