### PR TITLE
feat: add FAQ entry for missing information and update command choices

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=6.0.16-SNAPSHOT
+version=6.0.17-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/discord/faq/Faq.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/faq/Faq.kt
@@ -53,6 +53,11 @@ enum class Faq(val id: String, val question: String, val answer: String) {
         translatable("faq.command.questions.maintenance.question"),
         translatable("faq.command.questions.maintenance.answer")
     ),
+    MISSING_INFORMATION(
+        "missing-information",
+        translatable("faq.command.questions.missing-information.question"),
+        translatable("faq.command.questions.missing-information.answer")
+    ),
     HOW_TO_SHARE_LOG(
         "how-to-share-log",
         translatable("faq.command.questions.how-to-share-log.question"),

--- a/src/main/kotlin/dev/slne/surf/discord/faq/command/FaqCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/faq/command/FaqCommand.kt
@@ -32,6 +32,7 @@ import kotlin.time.toJavaDuration
                 CommandChoice("problem-connection", "problem-connection"),
                 CommandChoice("read-the-docs", "read-the-docs"),
                 CommandChoice("maintenance", "maintenance"),
+                CommandChoice("missing-information", "missing-information"),
                 CommandChoice("how-to-share-log", "how-to-share-log"),
                 CommandChoice("clan-info", "clan-info"),
                 CommandChoice("take-part-in-event", "take-part-in-event"),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -186,6 +186,13 @@ faq.command.questions.read-the-docs.answer=Diese und weitere Fragen werden in un
 faq.command.questions.maintenance.question=Wartungsarbeiten am Netzwerk
 faq.command.questions.maintenance.answer=Aktuell finden Wartungsarbeiten am gesamten Netzwerk statt. \
   Bitte habe Geduld. Weitere Informationen findest du unter https://discord.com/channels/133198459531558912/980810495877607524
+faq.command.questions.missing-information.question=Fehlende Informationen
+faq.command.questions.missing-information.answer=Uns fehlen aktuell noch einige wichtige Informationen, um dein Anliegen bearbeiten zu können.\n\n\
+Bitte überprüfe noch einmal, ob du uns alle wichtigen Informationen mitgeteilt hast:\n\n\
+• **Server**, auf dem es aufgetreten ist\n\
+• **Koordinaten** (z. B. `110 64 60`)\n\
+• **Dimension** (z. B. `Overworld`)\n\
+• **Eine genaue Beschreibung des Problems**
 faq.command.questions.how-to-share-log.question=Wie teile ich meinen Log?
 faq.command.questions.how-to-share-log.answer=Eine Anleitung, wie du deinen Log teilst, findest du hier: [Anleitung](https://server.castcrafter.de/faq#find-minecraft-log)
 faq.command.questions.clan-info.question=Clan-Informationen


### PR DESCRIPTION
This pull request adds a new FAQ entry for cases where users have not provided enough information, updates the command choices to include this new FAQ, and provides the corresponding localized question and answer text. It also bumps the project version in `gradle.properties`.

**FAQ Feature Additions:**

* Added a new `MISSING_INFORMATION` entry to the `Faq` enum in `Faq.kt` to handle cases where support requests lack sufficient details.
* Added a new command choice `missing-information` to the FAQ command in `FaqCommand.kt`, allowing users to select this FAQ topic.

**Localization Updates:**

* Added new localized strings for the missing information FAQ (`faq.command.questions.missing-information.question` and `faq.command.questions.missing-information.answer`) to `messages.properties`. The answer text provides a checklist of required information for support requests.

**Version Update:**

* Bumped project version from `6.0.16-SNAPSHOT` to `6.0.17-SNAPSHOT` in `gradle.properties`.