### PR TITLE
✨ feat(ticket): add shop support ticket functionality

### DIFF
--- a/src/main/kotlin/dev/slne/surf/discord/interaction/modal/impl/ticket/ShopPurchaseTicketModal.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/interaction/modal/impl/ticket/ShopPurchaseTicketModal.kt
@@ -1,0 +1,128 @@
+package dev.slne.surf.discord.interaction.modal.impl.ticket
+
+import dev.slne.surf.discord.dsl.embed
+import dev.slne.surf.discord.dsl.modal
+import dev.slne.surf.discord.interaction.button.ButtonRegistry
+import dev.slne.surf.discord.interaction.modal.DiscordModal
+import dev.slne.surf.discord.messages.translatable
+import dev.slne.surf.discord.ticket.TicketService
+import dev.slne.surf.discord.ticket.TicketType
+import dev.slne.surf.discord.util.Colors
+import dev.slne.surf.discord.util.replyError
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import org.springframework.stereotype.Component
+
+@Component
+class ShopPurchaseTicketModal(
+    private val ticketService: TicketService,
+    private val buttonRegistry: ButtonRegistry,
+) : DiscordModal {
+    override val id = "ticket:shop:purchase"
+
+    override fun create() = modal(id, translatable("ticket.shop.purchase.modal.title")) {
+        textInput {
+            id = "minecraft_name"
+            label = translatable("ticket.shop.purchase.modal.field.minecraft_name.label")
+            style = TextInputStyle.SHORT
+            lengthRange = 3..16
+            placeholder = translatable("ticket.shop.purchase.modal.field.minecraft_name.placeholder")
+            required = true
+        }
+
+        textInput {
+            id = "order_id"
+            label = translatable("ticket.shop.purchase.modal.field.order_id.label")
+            style = TextInputStyle.SHORT
+            lengthRange = 3..100
+            placeholder = translatable("ticket.shop.purchase.modal.field.order_id.placeholder")
+            required = false
+        }
+
+        textInput {
+            id = "issue"
+            label = translatable("ticket.shop.purchase.modal.field.issue.label")
+            style = TextInputStyle.PARAGRAPH
+            lengthRange = 10..4000
+            placeholder = translatable("ticket.shop.purchase.modal.field.issue.placeholder")
+            required = true
+        }
+    }
+
+    override suspend fun onSubmit(event: ModalInteractionEvent) {
+        val interaction = event.interaction
+        val user = interaction.user
+
+        val minecraftName = interaction.getValue("minecraft_name")?.asString ?: return
+        val orderId = interaction.getValue("order_id")?.asString?.takeIf { it.isNotBlank() }
+        val issue = interaction.getValue("issue")?.asString ?: return
+
+        interaction.reply(translatable("ticket.creating")).setEphemeral(true).queue()
+
+        val ticket =
+            ticketService.createTicket(
+                interaction.hook,
+                TicketType.SHOP_PURCHASE,
+                buildMap {
+                    put("minecraft_name", minecraftName)
+                    orderId?.let { put("order_id", it) }
+                    put("issue", issue)
+                }
+            ) ?: run {
+                if (ticketService.hasOpenTicket(user.idLong, TicketType.SHOP_PURCHASE)) {
+                    interaction.hook.editOriginal(translatable("ticket.shop.purchase.already_open"))
+                        .queue()
+                } else {
+                    interaction.hook.replyError()
+                }
+                return
+            }
+
+        val thread = ticket.getThreadChannel() ?: run {
+            interaction.hook.replyError()
+            return
+        }
+
+        interaction.hook.editOriginal(translatable("ticket.created", thread.asMention))
+            .queue()
+
+        thread.sendMessage(user.asMention).queue()
+        thread.sendMessageEmbeds(
+            embed {
+                title = translatable("ticket.shop.purchase.embed.title")
+                description = translatable("ticket.shop.purchase.embed.description")
+                color = Colors.SUCCESS
+
+                field {
+                    name = translatable("ticket.shop.purchase.embed.field.minecraft_name")
+                    value = minecraftName
+                    inline = true
+                }
+
+                orderId?.let {
+                    field {
+                        name = translatable("ticket.shop.purchase.embed.field.order_id")
+                        value = it
+                        inline = true
+                    }
+                }
+
+                issue.chunked(1024).forEach { chunk ->
+                    field {
+                        name = translatable("ticket.shop.purchase.embed.field.issue")
+                        value = chunk
+                        inline = false
+                    }
+                }
+            }
+        ).addComponents(
+            ActionRow.of(
+                buttonRegistry.get("ticket:claim").button,
+                buttonRegistry.get("ticket:close").button
+            )
+        ).submit(true).thenAccept {
+            thread.pinMessageById(it.idLong).queue()
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/discord/permission/DiscordPermission.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/permission/DiscordPermission.kt
@@ -33,6 +33,7 @@ enum class DiscordPermission {
     TICKET_UNBAN_VIEW,
     TICKET_BUG_VIEW,
     TICKET_COMPLAINT_VIEW,
+    TICKET_SHOP_VIEW,
 
     TICKET_TYPE_BYPASS,
 

--- a/src/main/kotlin/dev/slne/surf/discord/ticket/TicketType.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/TicketType.kt
@@ -175,5 +175,14 @@ enum class TicketType(
         viewPermission = DiscordPermission.TICKET_COMPLAINT_VIEW,
         closeReasons = defaultReasons,
         modal = modalRegistry.get("ticket:complaint").create()
+    ),
+    SHOP_PURCHASE(
+        id = "shop",
+        displayName = "Shop Support",
+        description = "Erstelle ein Ticket, wenn du Unterstützung zu In-Game-Käufen brauchst.",
+        emoji = "🛒",
+        viewPermission = DiscordPermission.TICKET_SHOP_VIEW,
+        closeReasons = defaultReasons,
+        modal = modalRegistry.get("ticket:shop:purchase").create()
     );
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -78,8 +78,22 @@ ticket.support.survival.modal.field.issue.label=Anliegen
 ticket.support.survival.modal.field.issue.placeholder=Meine Items sind weg, ich wurde geghosted.
 ticket.support.survival.already_open=Du hast bereits ein offenes Survival-Support-Ticket.
 ticket.support.survival.embed.title=Willkommen im Ticket!
-ticket.support.survival.embed.description=Dein Survival Support wurde erstellt und wir haben deine Informationen erhalten. Bitte habe ein wenig Geduld, während das Team dein Anliegen bearbeitet.
+ticket.support.survival.embed.description=Dein Survival Support Ticket wurde erstellt und wir haben deine Informationen erhalten. Bitte habe ein wenig Geduld, während das Team dein Anliegen bearbeitet.
 ticket.support.survival.embed.field.issue=Anliegen
+# Ticket: Shop Purchase
+ticket.shop.purchase.modal.title=Shop Support erstellen
+ticket.shop.purchase.modal.field.minecraft_name.label=Minecraft Name
+ticket.shop.purchase.modal.field.minecraft_name.placeholder=Keviro
+ticket.shop.purchase.modal.field.order_id.label=Transaktions-ID (falls vorhanden)
+ticket.shop.purchase.modal.field.order_id.placeholder=tbx-...
+ticket.shop.purchase.modal.field.issue.label=Anliegen
+ticket.shop.purchase.modal.field.issue.placeholder=Ich habe Fragen oder brauche Unterstützung zu einem In-Game-Kauf.
+ticket.shop.purchase.already_open=Du hast bereits ein offenes Shop-Support-Ticket.
+ticket.shop.purchase.embed.title=Shop Support
+ticket.shop.purchase.embed.description=Dein Ticket wurde erstellt. Bitte habe ein wenig Geduld, während das Team dein Anliegen bearbeitet.
+ticket.shop.purchase.embed.field.minecraft_name=Minecraft Name
+ticket.shop.purchase.embed.field.order_id=Transaktions-ID
+ticket.shop.purchase.embed.field.issue=Anliegen
 # Ticket: Report
 ticket.report.modal.title=Report Ticket erstellen
 ticket.report.modal.field.target.label=Spielername


### PR DESCRIPTION
This pull request introduces a new "Shop Support" ticket type for Discord, allowing users to request help with in-game purchases. The implementation includes a new modal for ticket creation, updates to permissions, ticket types, and localization messages.

**Shop Support Ticket Feature:**

* Added a new `ShopPurchaseTicketModal` class to handle the creation and submission of shop support tickets, including user input validation and ticket thread creation.
* Introduced the `SHOP_PURCHASE` entry to the `TicketType` enum, specifying its display name, description, emoji, required permission, and associated modal.

**Permissions:**

* Added a new `TICKET_SHOP_VIEW` permission to the `DiscordPermission` enum for controlling access to shop support tickets.

**Localization:**

* Added all necessary localization strings for the new shop support ticket modal and embed messages in `messages.properties`.