### PR TITLE
feat: render mytickets as embed with thread mentions and panel links

### DIFF
--- a/src/main/kotlin/dev/slne/surf/discord/ticket/command/context/MyTicketsCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/command/context/MyTicketsCommand.kt
@@ -2,10 +2,12 @@ package dev.slne.surf.discord.ticket.command.context
 
 import dev.slne.surf.discord.command.DiscordCommand
 import dev.slne.surf.discord.command.SlashCommand
+import dev.slne.surf.discord.dsl.embed
 import dev.slne.surf.discord.messages.translatable
 import dev.slne.surf.discord.permission.DiscordPermission
 import dev.slne.surf.discord.permission.hasPermission
 import dev.slne.surf.discord.ticket.database.ticket.TicketRepository
+import dev.slne.surf.discord.util.Colors
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import org.springframework.stereotype.Component
 
@@ -29,16 +31,24 @@ class MyTicketsCommand(
             .filter { it.threadId != null }
             .sortedByDescending { it.createdAt }
 
-        val text = if (tickets.isEmpty()) {
-            translatable("ticket.command.mytickets.empty")
-        } else {
-            tickets.mapIndexed { index, ticket ->
-                val threadUrl = "https://discord.com/channels/${ticket.guildId}/${ticket.threadId}"
-                val panelUrl = "$PANEL_BASE_URL/${ticket.ticketId}"
-                "#${index + 1} <$threadUrl> |--| <$panelUrl>"
-            }.joinToString("\n")
+        if (tickets.isEmpty()) {
+            event.replyEmbeds(embed {
+                title = translatable("ticket.command.mytickets.title")
+                description = translatable("ticket.command.mytickets.empty")
+                color = Colors.INFO
+            }).setEphemeral(true).queue()
+            return
         }
 
-        event.reply(text).setEphemeral(true).queue()
+        event.replyEmbeds(embed {
+            title = translatable("ticket.command.mytickets.title")
+            color = Colors.PRIMARY
+            footer = translatable("ticket.command.mytickets.footer", tickets.size.toString())
+
+            description = tickets.mapIndexed { index, ticket ->
+                val panelUrl = "$PANEL_BASE_URL/${ticket.ticketId}"
+                "`#${index + 1}` <#${ticket.threadId}> → [Im Panel ansehen]($panelUrl)"
+            }.joinToString("\n")
+        }).setEphemeral(true).queue()
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -40,6 +40,8 @@ ticket.command.remove.not-member={0} ist kein Mitglied in diesem Ticket.
 ticket.command.until.not-positive=Die angegebene Zeit muss größer als 0 Stunden sein.
 ticket.command.until.to-high=Die angegebene Zeit muss kleiner als 8767 Stunden (1 Jahr) sein.
 # Ticket: My Tickets
+ticket.command.mytickets.title=Deine offenen Tickets
+ticket.command.mytickets.footer={0} offene(s) Ticket(s)
 ticket.command.mytickets.empty=Du bearbeitest aktuell keine Tickets.
 # Ticket: Bugreport
 ticket.bugreport.modal.title=Bugreport erstellen


### PR DESCRIPTION
List each claimed ticket in one line as `#n <#thread> → panel link`, add title and footer message keys.