### PR TITLE
Add error handling for DM notifications in notifyDeadlineCreator

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=6.0.28
+version=6.0.29

--- a/src/main/kotlin/dev/slne/surf/discord/ticket/deadline/ReplyDeadlineService.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/deadline/ReplyDeadlineService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
@@ -85,16 +86,32 @@ class ReplyDeadlineService(
     }
 
     private suspend fun notifyDeadlineCreator(deadline: ReplyDeadline) {
-        val privateChannel = jda.openPrivateChannelById(deadline.setById).await()
+        try {
+            val privateChannel = jda.openPrivateChannelById(deadline.setById).await()
+            privateChannel.sendMessageEmbeds(embed {
+                title = translatable("ticket.reply-deadline.notify.title")
+                description = translatable(
+                    "ticket.reply-deadline.notify.description",
+                    "<@${deadline.targetUserId}>",
+                    "<#${deadline.threadId}>"
+                )
+                color = Colors.WARNING
+            }).await()
+        } catch (e: ErrorResponseException) {
+            when (e.errorCode) {
+                50007, 50278 -> {
+                    logger.info(
+                        "Cannot DM reply-deadline notification to user {} for deadline {}. " +
+                                "The user likely disabled server DMs, blocked the bot, or Discord rejected the DM. code={}",
+                        deadline.setById,
+                        deadline.id,
+                        e.errorCode
+                    )
+                    return
+                }
 
-        privateChannel.sendMessageEmbeds(embed {
-            title = translatable("ticket.reply-deadline.notify.title")
-            description = translatable(
-                "ticket.reply-deadline.notify.description",
-                "<@${deadline.targetUserId}>",
-                "<#${deadline.threadId}>"
-            )
-            color = Colors.WARNING
-        }).await()
+                else -> throw e
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request updates the project version and improves error handling for user notifications in the reply deadline service. The main focus is on making the notification process more robust by gracefully handling failures when sending direct messages to users.

**Dependency update:**
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L1-R1): Bumped the project version from `6.0.28` to `6.0.29`.

**Error handling improvements in notification service:**
* [`ReplyDeadlineService.kt`](diffhunk://#diff-da706186590385d536a68b1279f9a700a9d83b20221aab46deb34f3d39899420R19): Added import for `ErrorResponseException` to handle Discord API errors.
* [`ReplyDeadlineService.kt`](diffhunk://#diff-da706186590385d536a68b1279f9a700a9d83b20221aab46deb34f3d39899420R89-L89): Wrapped the DM notification logic in a `try-catch` block to catch `ErrorResponseException`. If the error code indicates the user cannot be DM'd (e.g., DMs disabled, blocked bot, or Discord rejected the DM), the error is logged and the function returns gracefully; other errors are rethrown. [[1]](diffhunk://#diff-da706186590385d536a68b1279f9a700a9d83b20221aab46deb34f3d39899420R89-L89) [[2]](diffhunk://#diff-da706186590385d536a68b1279f9a700a9d83b20221aab46deb34f3d39899420R100-R115)