### PR TITLE
fix(database): use native UUID ticket member ids on PostgreSQL

### DIFF
--- a/src/main/kotlin/dev/slne/surf/discord/ticket/database/deadline/DeadlineNotifyRepository.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/database/deadline/DeadlineNotifyRepository.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository
 class DeadlineNotifyRepository {
 
     suspend fun setEnabled(userId: Long, enabled: Boolean) = suspendTransaction {
-        DeadlineNotifyTable.upsert {
+        DeadlineNotifyTable.upsert(DeadlineNotifyTable.userId) {
             it[DeadlineNotifyTable.userId] = userId
             it[DeadlineNotifyTable.enabled] = enabled
         }

--- a/src/main/kotlin/dev/slne/surf/discord/ticket/database/members/TicketMemberRepository.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/database/members/TicketMemberRepository.kt
@@ -24,7 +24,7 @@ class TicketMemberRepository {
         addedByName: String,
         addedByAvatarUrl: String?
     ) = suspendTransaction {
-        TicketMemberTable.upsert {
+        TicketMemberTable.upsert(TicketMemberTable.ticketId, TicketMemberTable.memberId) {
             it[ticketId] = ticket.ticketId
             it[memberId] = userId
             it[memberName] = userName

--- a/src/main/kotlin/dev/slne/surf/discord/ticket/database/members/TicketMemberTable.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/database/members/TicketMemberTable.kt
@@ -1,12 +1,12 @@
 package dev.slne.surf.discord.ticket.database.members
 
+import dev.slne.surf.discord.ticket.database.column.nativeUuid
 import dev.slne.surf.discord.ticket.database.column.zonedDateTime
 import dev.slne.surf.discord.ticket.database.util.schemedName
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
-import java.util.*
 
 object TicketMemberTable : LongIdTable(schemedName("ticket_members")) {
-    val ticketId = varchar("ticket_id", 50).transform({ UUID.fromString(it) }, { it.toString() })
+    val ticketId = nativeUuid("ticket_id")
     val memberId = varchar("member_id", 255).transform({ it.toLong() }, { it.toString() })
     val memberName = varchar("member_name", 255)
     val memberAvatarUrl = varchar("member_avatar_url", 255).nullable()


### PR DESCRIPTION
## Summary

Fixes the PostgreSQL runtime failure:

```text
[42804] column "ticket_id" is of type uuid but expression is of type character varying
```

`ticket_members.ticket_id` is a native PostgreSQL `uuid` column in the migrated database, but `TicketMemberTable` declared it as `varchar(...).transform(...)`. Exposed therefore bound the insert value as `VARCHAR`, which PostgreSQL does not implicitly cast to `UUID` for the prepared insert.

## Changes

- declare `TicketMemberTable.ticketId` with the existing `nativeUuid("ticket_id")` column type
- use the actual business unique key `(ticket_id, member_id)` as the PostgreSQL upsert conflict target
- use `ticket_deadline_notify.user_id` as the conflict target for its parameterless upsert as well

The explicit conflict targets prevent the next PostgreSQL failure where Exposed would otherwise target the technical `id` primary key instead of the unique business key.

## Current database verification

```sql
SELECT table_schema, table_name, column_name, data_type, udt_name
FROM information_schema.columns
WHERE table_schema = 'surf-discord'
  AND table_name IN ('ticket_members', 'ticket_deadline_notify')
  AND column_name IN ('ticket_id', 'user_id');

SELECT schemaname, tablename, indexname, indexdef
FROM pg_indexes
WHERE schemaname = 'surf-discord'
  AND tablename IN ('ticket_members', 'ticket_deadline_notify');
```

Expected:

- `ticket_members.ticket_id` has PostgreSQL type `uuid`
- a unique index/constraint exists on `(ticket_id, member_id)`
- a unique index/constraint exists on `ticket_deadline_notify.user_id`

No data migration is required when `ticket_members.ticket_id` is already `uuid`, as shown by the reported error.

## Validation

- branch is based on `version/7.0.0`
- only the affected table definition and two repositories are changed
- project build/tests still need to run in CI or a local checkout
