### PR TITLE
fix(database): bind ticket table IDs as native UUIDs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.0.1
+version=7.0.2

--- a/src/main/kotlin/dev/slne/surf/discord/ticket/database/ticket/TicketTable.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/database/ticket/TicketTable.kt
@@ -1,13 +1,13 @@
 package dev.slne.surf.discord.ticket.database.ticket
 
 import dev.slne.surf.discord.ticket.TicketType
+import dev.slne.surf.discord.ticket.database.column.nativeUuid
 import dev.slne.surf.discord.ticket.database.column.zonedDateTime
 import dev.slne.surf.discord.ticket.database.util.schemedName
 import org.jetbrains.exposed.v1.core.dao.id.ULongIdTable
-import java.util.*
 
 object TicketTable : ULongIdTable(schemedName("ticket_tickets")) {
-    val ticketId = char("ticket_id", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val ticketId = nativeUuid("ticket_id")
     val authorId =
         varchar("ticket_author_id", 20).transform({ it.toLong() }, { it.toString() })
     val authorName = varchar("ticket_author_name", 64)


### PR DESCRIPTION
## Summary

Fixes the remaining PostgreSQL ticket creation failure:

```text
[42804] column "ticket_id" is of type uuid but expression is of type character varying
```

PR #105 fixed `ticket_members.ticket_id`, but the actual ticket creation path uses `TicketRepository.createTicket()` and inserts into `ticket_tickets`. `TicketTable.ticketId` was still declared as `char("ticket_id", 36).transform(...)`, so Exposed bound the prepared statement value as `VARCHAR` while PostgreSQL expects `uuid`.

## Changes

- declare `TicketTable.ticketId` with the existing `nativeUuid("ticket_id")` column type
- remove the no-longer-needed `java.util.*` import
- bump version from `7.0.1` to `7.0.2`

## Database verification

```sql
SELECT table_schema, table_name, column_name, data_type, udt_name
FROM information_schema.columns
WHERE table_schema = 'surf-discord'
  AND table_name = 'ticket_tickets'
  AND column_name = 'ticket_id';
```

Expected:

```text
data_type = uuid
udt_name  = uuid
```

No data migration is required when the database column is already `uuid`, as indicated by the runtime error.

## Validation

- branch is based on the merged PR #105 state of `version/7.0.0`
- only `TicketTable.ticketId` and the project version are changed
- local build/tests were not run in this environment; CI or a local checkout still needs to verify compilation
