### PR TITLE
fix(database): repair PostgreSQL upsert constraints

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.0.2
+version=7.0.3

--- a/src/main/kotlin/dev/slne/surf/discord/config/DatabaseConfig.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/config/DatabaseConfig.kt
@@ -6,6 +6,7 @@ import dev.slne.surf.discord.ticket.database.deadline.ReplyDeadlineTable
 import dev.slne.surf.discord.ticket.database.members.TicketMemberTable
 import dev.slne.surf.discord.ticket.database.messages.TicketMessagesTable
 import dev.slne.surf.discord.ticket.database.messages.attachments.TicketAttachmentsTable
+import dev.slne.surf.discord.ticket.database.migration.migratePostgreSqlUpsertConstraints
 import dev.slne.surf.discord.ticket.database.ticket.TicketTable
 import dev.slne.surf.discord.ticket.database.ticket.data.TicketDataTable
 import dev.slne.surf.discord.ticket.database.ticket.staff.TicketStaffTable
@@ -54,6 +55,7 @@ class DatabaseConfiguration {
                     ReplyDeadlineTable,
                     DeadlineNotifyTable
                 )
+                migratePostgreSqlUpsertConstraints()
             }
             logger.info("Connected to database (PostgreSQL) ${botConfig.database.database} at ${botConfig.database.hostname}:${botConfig.database.port}")
         }

--- a/src/main/kotlin/dev/slne/surf/discord/ticket/database/migration/PostgreSQLUpsertConstraintMigration.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/ticket/database/migration/PostgreSQLUpsertConstraintMigration.kt
@@ -1,0 +1,51 @@
+package dev.slne.surf.discord.ticket.database.migration
+
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+
+/**
+ * Repairs business-key constraints required by PostgreSQL upserts on databases created before the
+ * explicit conflict targets were introduced.
+ *
+ * Existing duplicate rows are reduced to the row with the highest technical ID before the unique
+ * indexes are created. The migration is safe to execute on every startup.
+ */
+suspend fun migratePostgreSqlUpsertConstraints() {
+    if (currentDialect !is PostgreSQLDialect) return
+
+    val transaction = TransactionManager.current()
+
+    transaction.exec(
+        """
+        DELETE FROM "surf-discord".ticket_members AS older
+        USING "surf-discord".ticket_members AS newer
+        WHERE older.ticket_id = newer.ticket_id
+          AND older.member_id = newer.member_id
+          AND older.id < newer.id
+        """.trimIndent()
+    )
+
+    transaction.exec(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ticket_members_ticket_id_member_id_uq_idx
+        ON "surf-discord".ticket_members (ticket_id, member_id)
+        """.trimIndent()
+    )
+
+    transaction.exec(
+        """
+        DELETE FROM "surf-discord".ticket_deadline_notify AS older
+        USING "surf-discord".ticket_deadline_notify AS newer
+        WHERE older.user_id = newer.user_id
+          AND older.id < newer.id
+        """.trimIndent()
+    )
+
+    transaction.exec(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ticket_deadline_notify_user_id_uq_idx
+        ON "surf-discord".ticket_deadline_notify (user_id)
+        """.trimIndent()
+    )
+}


### PR DESCRIPTION
## Summary

Fixes the PostgreSQL runtime failure seen after deploying `7.0.2`:

```text
[42P10] there is no unique or exclusion constraint matching the ON CONFLICT specification
```

The application now correctly uses explicit PostgreSQL upsert conflict targets:

- `ticket_members(ticket_id, member_id)`
- `ticket_deadline_notify(user_id)`

However, existing databases created before those business-key indexes were declared can still lack the corresponding unique indexes. `SchemaUtils.create(...)` creates missing tables, but it does not reliably repair indexes on existing tables.

## Changes

- add an idempotent PostgreSQL startup migration
- remove duplicate legacy rows while keeping the row with the highest technical `id`
- create the required unique indexes:
  - `ticket_members_ticket_id_member_id_uq_idx`
  - `ticket_deadline_notify_user_id_uq_idx`
- run the migration immediately after `SchemaUtils.create(...)`
- bump version from `7.0.2` to `7.0.3`

## Pre-deployment duplicate check

```sql
SELECT ticket_id, member_id, COUNT(*)
FROM "surf-discord".ticket_members
GROUP BY ticket_id, member_id
HAVING COUNT(*) > 1;

SELECT user_id, COUNT(*)
FROM "surf-discord".ticket_deadline_notify
GROUP BY user_id
HAVING COUNT(*) > 1;
```

The migration keeps the row with the greatest `id` for each duplicate business key.

## Index verification

```sql
SELECT schemaname, tablename, indexname, indexdef
FROM pg_indexes
WHERE schemaname = 'surf-discord'
  AND tablename IN ('ticket_members', 'ticket_deadline_notify')
ORDER BY tablename, indexname;
```

Expected unique indexes:

- `ticket_members(ticket_id, member_id)`
- `ticket_deadline_notify(user_id)`

## Log notes

The additional Logback warnings about missing `CONSOLE` appenders and the Java native-access warning are unrelated to this database failure and do not stop startup.

## Validation

- branch is based on the merged `7.0.2` state of `version/7.0.0`
- only startup schema repair and the version are changed
- local build/tests were not run in this environment; CI or a local checkout still needs to verify compilation and migration behavior
