### PR TITLE
✨ feat(link): add command listener for /link with user guidance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=7.1.0
+version=7.1.1
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true

--- a/src/main/kotlin/dev/slne/surf/discord/DiscordMicroservice.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/DiscordMicroservice.kt
@@ -13,6 +13,7 @@ import dev.slne.surf.discord.contextmenu.ContextCommandRegistrar
 import dev.slne.surf.discord.interaction.button.ButtonListener
 import dev.slne.surf.discord.interaction.modal.ModalListener
 import dev.slne.surf.discord.interaction.selectmenu.SelectMenuListener
+import dev.slne.surf.discord.listener.LinkCommandListener
 import dev.slne.surf.discord.messages.MessageService
 import dev.slne.surf.discord.premium.PremiumService
 import dev.slne.surf.discord.redis.RedisService
@@ -83,7 +84,8 @@ class DiscordMicroservice : Microservice() {
             SelectMenuListener,
             ButtonListener,
             ModalListener,
-            ContextCommandRegistrar
+            ContextCommandRegistrar,
+            LinkCommandListener
         )
 
         discordScope.runAtFixedRate(1.minutes) {

--- a/src/main/kotlin/dev/slne/surf/discord/listener/LinkCommandListener.kt
+++ b/src/main/kotlin/dev/slne/surf/discord/listener/LinkCommandListener.kt
@@ -1,0 +1,40 @@
+package dev.slne.surf.discord.listener
+
+import dev.minn.jda.ktx.coroutines.await
+import dev.slne.surf.discord.discordScope
+import dev.slne.surf.discord.messages.translatable
+import dev.slne.surf.discord.util.Colors
+import kotlinx.coroutines.launch
+import net.dv8tion.jda.api.components.container.Container
+import net.dv8tion.jda.api.components.container.ContainerChildComponent
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+
+private val LINK_COMMAND_REGEX = Regex("""^/link(?: +[\w-]+)?$""", RegexOption.IGNORE_CASE)
+
+object LinkCommandListener : ListenerAdapter() {
+    private fun linkComponent(userMention: String): Container {
+        val components = mutableListOf<ContainerChildComponent>()
+
+        components += TextDisplay.of("## ${translatable("link.wrong-place.title")}")
+        components += TextDisplay.of(translatable("link.wrong-place.description"))
+        components += TextDisplay.of("-# $userMention")
+
+        return Container.of(components).withAccentColor(Colors.INFO)
+    }
+
+    override fun onMessageReceived(event: MessageReceivedEvent) {
+        if (event.author.isBot || event.isWebhookMessage) return
+        if (!event.isFromGuild || event.channel is ThreadChannel) return
+        if (!LINK_COMMAND_REGEX.matches(event.message.contentRaw.trim())) return
+
+        discordScope.launch {
+            event.message.replyComponents(linkComponent(event.author.asMention))
+                .useComponentsV2()
+                .mention(event.author)
+                .await()
+        }
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -167,6 +167,12 @@ whitelist.embed.information.title=Whitelistinformation
 whitelist.embed.information.minecraft=Minecraft Name
 whitelist.embed.information.discord=Discord Benutzer
 whitelist.embed.information.blocked=Blockiert
+# Link
+link.wrong-place.title=Falscher Ort für /link
+link.wrong-place.description=Den Befehl `/link <code>` musst du **ingame** auf dem CastCrafter Server ausführen und nicht hier im Discord.\n\n\
+  Verbinde dich also mit dem Minecraft Server, öffne dort den Chat und gib den Befehl mit deinem Code ein.\n\n\
+  Du weißt nicht, wie du auf den Server kommst? Hier findest du eine Anleitung: \
+  [Wie joine ich?](https://docs.castcrafter.de/how-to-join.html)
 # Rollback: Full
 rollback.command.full.title=Voll-Rollback: {0}
 rollback.command.full.field.uuid=Minecraft UUID

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -172,7 +172,7 @@ link.wrong-place.title=Falscher Ort für /link
 link.wrong-place.description=Den Befehl `/link <code>` musst du **ingame** auf dem CastCrafter Server ausführen und nicht hier im Discord.\n\n\
   Verbinde dich also mit dem Minecraft Server, öffne dort den Chat und gib den Befehl mit deinem Code ein.\n\n\
   Du weißt nicht, wie du auf den Server kommst? Hier findest du eine Anleitung: \
-  [Wie joine ich?](https://docs.castcrafter.de/how-to-join.html)
+  [Wie joine ich?](https://docs.castcrafter.de/how-to-join)
 # Rollback: Full
 rollback.command.full.title=Voll-Rollback: {0}
 rollback.command.full.field.uuid=Minecraft UUID


### PR DESCRIPTION
This pull request introduces a new listener to handle the `/link` command in Discord and provides user guidance for its correct usage. The main changes include registering the new `LinkCommandListener`, implementing its logic, and adding related user-facing messages.

**New `/link` command handling:**

* Added a new `LinkCommandListener` to process `/link` commands sent in the wrong Discord channel, guiding users to use the command in-game instead. (`src/main/kotlin/dev/slne/surf/discord/listener/LinkCommandListener.kt`)
* Registered `LinkCommandListener` in the `DiscordMicroservice` so it is active and listens for relevant messages. (`src/main/kotlin/dev/slne/surf/discord/DiscordMicroservice.kt`) [[1]](diffhunk://#diff-dfcf8d9fffe6a696f288212c657f8ee20fbe5512b4d0529a153e426ddc835689R16) [[2]](diffhunk://#diff-dfcf8d9fffe6a696f288212c657f8ee20fbe5512b4d0529a153e426ddc835689L86-R88)

**Localization and user messaging:**

* Added new message keys and German-language instructions to `messages.properties`, informing users that the `/link` command must be used in-game and providing a help link. (`src/main/resources/messages.properties`)